### PR TITLE
feat: Ask loop walking skeleton (#13)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A personal fantasy football assistant for one Sleeper league. Deterministic Java
 mvn test
 ```
 
-The tests boot the real Spring context and invoke the Check entry point directly. Stub HTTP servers play Sleeper, Telegram, and the LLM with recorded fixtures. No test touches the network or spends tokens.
+The tests boot the real Spring context and invoke the two entry points - the Check and the Telegram webhook - directly. Stub HTTP servers play Sleeper, Telegram, and the LLM with recorded fixtures, including canned tool-call sequences for the Ask loop. No test touches the network or spends tokens.
 
 ## Run a Check loop locally
 
@@ -27,3 +27,7 @@ SPRING_PROFILES_ACTIVE=local mvn spring-boot:run
 ```
 
 The loop runs one Check every 60 seconds. In a pre-draft league the cadence gate inside the Check drops this to one full Check per day, and no roster Alerts fire.
+
+## Ask the bot
+
+Text the bot in plain language and the Ask loop answers. A tool-calling agent routes the question to deterministic tools - the roster, the league settings, the optimal lineup, and what-if swaps - and words what they computed; it never computes a number itself. Replies run 2 to 5 lines; reply "why" or "more" for the full reasoning. The loop answers only the configured chat, and it reads the Snapshot the last Check stored.

--- a/docs/adr/0002-ask-loop-semantics.md
+++ b/docs/adr/0002-ask-loop-semantics.md
@@ -50,8 +50,13 @@ slots out of the sum.
 
 "What if I start Goedert" names one player, not a swap. The answer
 prices the swap the user would actually make: the weakest starter whose
-slot accepts the incoming player makes the room. Naming a sit-side
-player explicitly always wins over this default.
+slot accepts the incoming player makes the room.
+
+Picking for the user only ever picks a slot he can still free, so a
+starter whose game has kicked off is skipped even when he projects
+lowest. Naming a sit-side player explicitly always wins over this
+default, and still prices a locked swap rather than refusing it - with
+`legal: false` on the answer.
 
 ## "Legal" in a what-if means Sleeper would take it
 
@@ -70,11 +75,12 @@ the model call, so a stray or replayed update can never spend tokens.
 ## Depth is a reply-length control, not a mode
 
 "why", "more" and their kin swap the closing instruction of the system
-prompt from the 2-to-5-line brief to a full-reasoning one. A depth word
-only counts inside a short message, so "I want more points from my
-flex" stays a fresh question. There is no stored mode: the next
-ordinary question is short again, which is what "short by default" has
-to mean.
+prompt from the 2-to-5-line brief to a full-reasoning one. A question
+that starts with "why" counts however long it runs, because it always
+asks about the answer before it. Any other depth word counts only
+inside a short message, so "I want more points from my flex" stays a
+fresh question. There is no stored mode: the next ordinary question is
+short again, which is what "short by default" has to mean.
 
 ## An outage reply is not an answer
 

--- a/docs/adr/0002-ask-loop-semantics.md
+++ b/docs/adr/0002-ask-loop-semantics.md
@@ -1,0 +1,84 @@
+# ADR-0002: Ask loop semantics
+
+Status: accepted (2026-08-08, issue #13)
+
+The spec pins the two LLM lanes, the twelve tools and the rolling
+conversation window. It leaves a few semantic gaps that the Lane A
+walking skeleton had to close. This ADR records those decisions.
+
+## Asks read the stored Snapshot; they never build a new one
+
+The Check owns Sleeper's polling cadence, and the Freshness Ceiling
+means a fresh poll would not be fresher anyway. So an Ask answers from
+the current Snapshot. Before the first Check the tool says it has no
+Snapshot instead of building one, which keeps one writer for Snapshot
+state.
+
+Week facts (the week, the projections priced in league scoring, the
+starting slots, the week's games) are the exception: both lanes build
+them through `WeekFactsBuilder`, so a Check and an Ask read one week
+the same way, with the same fail-soft self-reports.
+
+The consequence, recorded plainly: an Ask still reads the league
+document and those week facts through the adapter on every question.
+Those reads are conditional GETs against the same ETag cache the Check
+fills, so they cost a 304 rather than a payload, but they are not free.
+The spec's per-tool rule - "a tool fetches live only when its data is
+older than its cadence interval" - is not implemented here. It wants a
+per-source fetch clock that the Check must not share, because the
+Check's whole job is to poll every minute. That belongs with the
+remaining tools, not with the first four.
+
+## Locked players keep their slots in the optimal lineup
+
+Sleeper locks a player at their game's kickoff, bench included. A
+lineup recommendation that moved a locked player would recommend
+something the user cannot do. So `recommend_lineup` pins locked
+starters to their slots and optimizes only what is still movable. Both
+totals count the locked players, so the current and optimal numbers
+compare like for like.
+
+## A lineup total is what the lineup scores as set
+
+A starter who cannot play (ruled out, on bye) or who has no projection
+counts zero in the total, never "no projection available". The slot
+line still carries the reason, so the model can name the zero. Without
+this rule an illegal lineup would flatter itself by leaving its dead
+slots out of the sum.
+
+## A what-if without a player to sit uses the weakest slot the fit allows
+
+"What if I start Goedert" names one player, not a swap. The answer
+prices the swap the user would actually make: the weakest starter whose
+slot accepts the incoming player makes the room. Naming a sit-side
+player explicitly always wins over this default.
+
+## "Legal" in a what-if means Sleeper would take it
+
+`whatif_lineup` reports `legal: false` only when the slot rejects the
+position or one of the two players has locked. Starting a player on
+bye or ruled Out is a legal lineup and a certain zero; that belongs in
+the notes, not in a legality flag, so the two failures stay tellable
+apart.
+
+## Only the configured chat reaches the Ask loop
+
+The webhook secret guards the endpoint, and the assistant serves one
+user by design. A text message from any other chat is dropped before
+the model call, so a stray or replayed update can never spend tokens.
+
+## Depth is a reply-length control, not a mode
+
+"why", "more" and their kin swap the closing instruction of the system
+prompt from the 2-to-5-line brief to a full-reasoning one. A depth word
+only counts inside a short message, so "I want more points from my
+flex" stays a fresh question. There is no stored mode: the next
+ordinary question is short again, which is what "short by default" has
+to mean.
+
+## An outage reply is not an answer
+
+When the model is unreachable the user still gets an honest line, but
+the exchange is not recorded in the conversation window. A spell of
+outages would otherwise evict the real conversation and come back to
+the model later as its own prior words.

--- a/src/main/java/otto/alerts/BenchEdgeDetector.java
+++ b/src/main/java/otto/alerts/BenchEdgeDetector.java
@@ -2,19 +2,17 @@ package otto.alerts;
 
 import java.time.Instant;
 import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Set;
 
 import org.springframework.stereotype.Component;
 
 import otto.OttoProperties;
 import otto.check.WeekFacts;
 import otto.lineup.LineupOptimizer;
+import otto.lineup.LineupSwap;
 import otto.lineup.ProjectionTable;
 import otto.lineup.Slot;
 import otto.snapshot.RosterSnapshot;
@@ -60,36 +58,14 @@ public class BenchEdgeDetector {
 
         Map<Integer, String> optimal =
                 optimizer.assign(slots, points, roster.playerPositions());
-        Set<String> optimalIds = new HashSet<>(optimal.values());
-        Set<String> currentIds = new HashSet<>(roster.starters());
-
-        // Both lists sort strongest first, so a multi-swap reshuffle
-        // pairs the best entering player with the best leaving one.
-        // Pairing best against worst would inflate one pair's edge and
-        // gate the threshold on a swap nobody would describe that way.
-        Comparator<String> strongestFirst = Comparator
-                .comparingDouble((String playerId) -> points.get(playerId))
-                .reversed();
-        List<String> entering = optimalIds.stream()
-                .filter(playerId -> !currentIds.contains(playerId))
-                .sorted(strongestFirst)
-                .toList();
-        List<String> leaving = currentIds.stream()
-                .filter(points::containsKey)
-                .filter(playerId -> !optimalIds.contains(playerId))
-                .sorted(strongestFirst)
-                .toList();
 
         List<AlertCandidate> candidates = new ArrayList<>();
-        int pairs = Math.min(entering.size(), leaving.size());
-        for (int pair = 0; pair < pairs; pair++) {
-            String in = entering.get(pair);
-            String out = leaving.get(pair);
-            double edge = points.get(in) - points.get(out);
-            if (edge < edgeThreshold) {
+        for (LineupSwap swap : optimizer.swaps(roster.starters(), optimal.values(), points)) {
+            if (swap.gain() < edgeThreshold) {
                 continue;
             }
-            candidates.add(candidate(roster, weekKey, slots, optimal, points, in, out, edge));
+            candidates.add(candidate(roster, weekKey, slots, optimal, points,
+                    swap.starting(), swap.sitting(), swap.gain()));
         }
         return candidates;
     }

--- a/src/main/java/otto/alerts/SelfReportService.java
+++ b/src/main/java/otto/alerts/SelfReportService.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Component;
 import otto.events.Event;
 import otto.events.EventLog;
 import otto.events.EventType;
+import otto.sleeper.SourceResult;
 import otto.telegram.TelegramClient;
 
 /**
@@ -26,6 +27,13 @@ public class SelfReportService {
         this.eventLog = eventLog;
         this.telegram = telegram;
         this.clock = clock;
+    }
+
+    /** Reports a source call that failed; an ok result is left alone. */
+    public void reportIfUnavailable(SourceResult<?> result) {
+        if (result instanceof SourceResult.Unavailable<?> unavailable) {
+            report(unavailable.source(), unavailable.reason());
+        }
     }
 
     public void report(String source, String reason) {

--- a/src/main/java/otto/ask/AskService.java
+++ b/src/main/java/otto/ask/AskService.java
@@ -5,7 +5,6 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
-import java.util.Optional;
 import java.util.Set;
 
 import org.slf4j.Logger;
@@ -55,11 +54,16 @@ public class AskService {
             the call. Stay inside the tool results.
             """;
 
-    /** What the user gets when the model cannot answer at all. */
+    /** What the user gets when the model cannot be reached at all. */
     private static final String UNREACHABLE = """
             I cannot reach my language model right now, so I cannot answer \
             that. My checks and alerts keep running, and I will answer once \
             it is back.""";
+
+    /** What the user gets when the model answers with nothing. */
+    private static final String EMPTY_ANSWER = """
+            My language model came back with nothing that time. Ask me \
+            again and I will have another go.""";
 
     private static final Set<String> DEPTH_WORDS =
             Set.of("why", "more", "detail", "details", "explain", "expand");
@@ -82,9 +86,19 @@ public class AskService {
         this.clock = clock;
     }
 
+    /** One run of the loop: the answer, or the failure to own up to. */
+    private sealed interface Outcome {
+
+        record Answered(String text) implements Outcome {
+        }
+
+        record Failed(String reply) implements Outcome {
+        }
+    }
+
     /**
      * Answers one Ask and records the exchange in the rolling window.
-     * An outage reply is not an answer, so it is never recorded: a
+     * A failure reply is not an answer, so it is never recorded: a
      * spell of them would otherwise evict the real conversation and
      * come back to the model as its own prior words.
      *
@@ -92,23 +106,42 @@ public class AskService {
      */
     public String answer(String question) {
         Instant now = clock.instant();
-        Optional<String> reply = run(question, now);
-        reply.ifPresent(answer -> conversation.record(now, question, answer));
-        return reply.orElse(UNREACHABLE);
+        return switch (run(question, now)) {
+            case Outcome.Answered answered -> {
+                conversation.record(now, question, answered.text());
+                yield answered.text();
+            }
+            case Outcome.Failed failed -> failed.reply();
+        };
     }
 
-    /** Empty when the model gave nothing back. */
-    private Optional<String> run(String question, Instant now) {
+    /**
+     * The two failures are told apart on purpose: a model that never
+     * answered is a different thing from one that answered with
+     * nothing, and claiming the wrong one would be a lie about what
+     * the assistant can see.
+     */
+    private Outcome run(String question, Instant now) {
         try {
             String content = chat.prompt()
                     .messages(prompt(question, now))
                     .tools(tools)
                     .call()
                     .content();
-            return content == null || content.isBlank() ? Optional.empty() : Optional.of(content);
+            if (content == null || content.isBlank()) {
+                log.warn("The model answered with no content");
+                return new Outcome.Failed(EMPTY_ANSWER);
+            }
+            return new Outcome.Answered(content);
         } catch (Exception e) {
+            // A wrapped interrupt must not die here: restore the flag
+            // so whatever runs this thread next still sees it.
+            if (e instanceof InterruptedException
+                    || e.getCause() instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+            }
             log.warn("Ask loop failed, answering with the outage reply", e);
-            return Optional.empty();
+            return new Outcome.Failed(UNREACHABLE);
         }
     }
 

--- a/src/main/java/otto/ask/AskService.java
+++ b/src/main/java/otto/ask/AskService.java
@@ -1,0 +1,146 @@
+package otto.ask;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.Set;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.messages.Message;
+import org.springframework.ai.chat.messages.SystemMessage;
+import org.springframework.ai.chat.messages.UserMessage;
+import org.springframework.stereotype.Component;
+
+/**
+ * Lane A: the Ask loop. Free text goes to a tool-calling agent loop
+ * over the deterministic tools, and the model narrates what they
+ * computed. The model owns the language and nothing else - every fact
+ * and every number reaches it from Java.
+ *
+ * Replies stay short by default. The user opens them up by asking
+ * "why" or "more", which is the only depth control the chat needs.
+ */
+@Component
+public class AskService {
+
+    private static final String SYSTEM = """
+            You are Otto, a fantasy football assistant texting your one
+            user about his Sleeper league team.
+
+            Every fact and every number comes from your tools. Call a tool
+            before you answer anything about his roster, his lineup or the
+            league, and repeat only what it returned. Never compute,
+            estimate or invent a projection, a point total, a matchup or a
+            name. When a tool reports it cannot answer, say plainly what
+            you cannot see rather than filling the gap.
+
+            He makes every roster change himself in the Sleeper app, so
+            recommend and never claim to have acted.
+            """;
+
+    private static final String BRIEF = """
+            Answer in 2 to 5 lines: the recommendation, then a one-line
+            reason. He will ask "why" or "more" when he wants the rest.
+            """;
+
+    private static final String DEEP = """
+            Give the full reasoning this time: the numbers your tools
+            returned, the alternatives they ranked, and what would change
+            the call. Stay inside the tool results.
+            """;
+
+    /** What the user gets when the model cannot answer at all. */
+    private static final String UNREACHABLE = """
+            I cannot reach my language model right now, so I cannot answer \
+            that. My checks and alerts keep running, and I will answer once \
+            it is back.""";
+
+    private static final Set<String> DEPTH_WORDS =
+            Set.of("why", "more", "detail", "details", "explain", "expand");
+
+    /** A depth word only opens up the last answer inside a short message. */
+    private static final int DEPTH_PHRASE_WORDS = 4;
+
+    private static final Logger log = LoggerFactory.getLogger(AskService.class);
+
+    private final ChatClient chat;
+    private final AskTools tools;
+    private final ConversationStore conversation;
+    private final Clock clock;
+
+    public AskService(ChatClient.Builder builder, AskTools tools,
+            ConversationStore conversation, Clock clock) {
+        this.chat = builder.build();
+        this.tools = tools;
+        this.conversation = conversation;
+        this.clock = clock;
+    }
+
+    /**
+     * Answers one Ask and records the exchange in the rolling window.
+     * An outage reply is not an answer, so it is never recorded: a
+     * spell of them would otherwise evict the real conversation and
+     * come back to the model as its own prior words.
+     *
+     * @return the reply text to send back to the chat
+     */
+    public String answer(String question) {
+        Instant now = clock.instant();
+        Optional<String> reply = run(question, now);
+        reply.ifPresent(answer -> conversation.record(now, question, answer));
+        return reply.orElse(UNREACHABLE);
+    }
+
+    /** Empty when the model gave nothing back. */
+    private Optional<String> run(String question, Instant now) {
+        try {
+            String content = chat.prompt()
+                    .messages(prompt(question, now))
+                    .tools(tools)
+                    .call()
+                    .content();
+            return content == null || content.isBlank() ? Optional.empty() : Optional.of(content);
+        } catch (Exception e) {
+            log.warn("Ask loop failed, answering with the outage reply", e);
+            return Optional.empty();
+        }
+    }
+
+    private List<Message> prompt(String question, Instant now) {
+        List<Message> messages = new ArrayList<>();
+        messages.add(new SystemMessage(SYSTEM + (wantsDepth(question) ? DEEP : BRIEF)));
+        for (ConversationStore.Turn turn : conversation.window(now)) {
+            messages.add(switch (turn.role()) {
+                case USER -> new UserMessage(turn.text());
+                case ASSISTANT -> new AssistantMessage(turn.text());
+            });
+        }
+        messages.add(new UserMessage(question));
+        return messages;
+    }
+
+    /**
+     * True when the message is the user opening up the last answer:
+     * "why", "more", "tell me more". A question that starts with "why"
+     * counts however long it runs; otherwise only a short message does,
+     * so "I want more points from my flex" stays a fresh question.
+     */
+    private boolean wantsDepth(String question) {
+        String normalized = question.trim().toLowerCase(Locale.ROOT)
+                .replaceAll("[^a-z ]", " ")
+                .replaceAll(" +", " ")
+                .trim();
+        if (normalized.equals("why") || normalized.startsWith("why ")) {
+            return true;
+        }
+        List<String> words = List.of(normalized.split(" "));
+        return words.size() <= DEPTH_PHRASE_WORDS
+                && words.stream().anyMatch(DEPTH_WORDS::contains);
+    }
+}

--- a/src/main/java/otto/ask/AskTools.java
+++ b/src/main/java/otto/ask/AskTools.java
@@ -1,0 +1,112 @@
+package otto.ask;
+
+import java.time.Clock;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import org.springframework.ai.tool.annotation.Tool;
+import org.springframework.ai.tool.annotation.ToolParam;
+import org.springframework.stereotype.Component;
+
+import otto.OttoProperties;
+import otto.sleeper.SleeperAdapter;
+import otto.sleeper.SourceResult;
+
+/**
+ * The tools the Lane A agent loop routes questions to. Each one runs
+ * deterministic Java and hands back computed facts; the model chooses
+ * which to call and writes the words, never the numbers.
+ *
+ * This is the first four of the twelve tools the spec names. Keep them
+ * coarse: one tool per question a user would ask, not one per field.
+ */
+@Component
+public class AskTools {
+
+    private final UserWeekLoader loader;
+    private final LineupPlanner planner;
+    private final Clock clock;
+    private final double edgeThreshold;
+
+    public AskTools(UserWeekLoader loader, LineupPlanner planner, Clock clock,
+            OttoProperties properties) {
+        this.loader = loader;
+        this.planner = planner;
+        this.clock = clock;
+        this.edgeThreshold = properties.edgeThreshold();
+    }
+
+    /** The league's rules, as the projection and lineup math applies them. */
+    public record LeagueSettings(String league, String status, List<String> rosterPositions,
+            Map<String, Double> scoring, String edgeThreshold) {
+    }
+
+    @Tool(name = "get_roster_status", description = """
+            The user's current roster this week: every starting slot with
+            who fills it, their projected points and what stops them
+            scoring, plus the bench with the same detail. Call this for
+            any question about who is on the team or how they look.""")
+    public ToolAnswer<LineupPlanner.RosterStatus> getRosterStatus() {
+        return switch (loader.load()) {
+            case SourceResult.Unavailable<UserWeek> unavailable -> unavailable(unavailable);
+            case SourceResult.Ok<UserWeek> ok ->
+                ToolAnswer.of(planner.rosterStatus(ok.value(), clock.instant()));
+        };
+    }
+
+    @Tool(name = "get_league_settings", description = """
+            The league's scoring settings, starting slots and status.
+            Call this whenever the answer depends on how the league
+            scores or which slots must be filled.""")
+    public ToolAnswer<LeagueSettings> getLeagueSettings() {
+        return switch (loader.league()) {
+            case SourceResult.Unavailable<SleeperAdapter.League> unavailable ->
+                unavailable(unavailable);
+            case SourceResult.Ok<SleeperAdapter.League> ok -> ToolAnswer.of(new LeagueSettings(
+                    ok.value().name(),
+                    ok.value().status(),
+                    ok.value().rosterPositions(),
+                    ok.value().scoringSettings(),
+                    String.format(Locale.ROOT, "%.1f", edgeThreshold)));
+        };
+    }
+
+    @Tool(name = "recommend_lineup", description = """
+            The optimal legal lineup for this week with the projected
+            point delta against the lineup the user has set now, and the
+            concrete start-over-sit swaps that get there. Call this for
+            "lineup", start/sit questions, and any request for the best
+            lineup.""")
+    public ToolAnswer<LineupPlanner.LineupPlan> recommendLineup() {
+        return switch (loader.load()) {
+            case SourceResult.Unavailable<UserWeek> unavailable -> unavailable(unavailable);
+            case SourceResult.Ok<UserWeek> ok -> planner.recommend(ok.value(), clock.instant());
+        };
+    }
+
+    @Tool(name = "whatif_lineup", description = """
+            Prices one hypothetical lineup change before the user acts:
+            the projected total with the change, the delta against the
+            current lineup, and whether the league would take it. Call
+            this for any "what if I start X" question.""")
+    public ToolAnswer<LineupPlanner.WhatIf> whatifLineup(
+            @ToolParam(description = "The player to start, by name or Sleeper player id")
+            String start,
+            @ToolParam(required = false, description = """
+                    The starter to sit, by name or Sleeper player id. Leave
+                    it out to sit the weakest starter whose slot accepts
+                    the incoming player.""")
+            String sit) {
+        return switch (loader.load()) {
+            case SourceResult.Unavailable<UserWeek> unavailable -> unavailable(unavailable);
+            case SourceResult.Ok<UserWeek> ok ->
+                planner.whatIf(ok.value(), clock.instant(), start, sit);
+        };
+    }
+
+    private static <T, R> ToolAnswer<R> unavailable(SourceResult.Unavailable<T> unavailable) {
+        return ToolAnswer.unavailable("%s: %s".formatted(
+                unavailable.source(), unavailable.reason()));
+    }
+}

--- a/src/main/java/otto/ask/ConversationStore.java
+++ b/src/main/java/otto/ask/ConversationStore.java
@@ -1,0 +1,71 @@
+package otto.ask;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+
+import com.fasterxml.jackson.databind.JavaType;
+import org.springframework.stereotype.Component;
+
+import otto.storage.JsonStore;
+import otto.storage.OttoJson;
+
+/**
+ * The rolling context the Ask loop carries between questions: the last
+ * day of conversation, capped at the last twenty messages. Both bounds
+ * matter - the cap keeps a busy Sunday inside one prompt, and the day
+ * keeps last week's start/sit talk from steering this week's answer.
+ */
+@Component
+public class ConversationStore {
+
+    private static final String DOCUMENT = "conversation";
+    private static final Duration WINDOW = Duration.ofHours(24);
+    private static final int MAX_MESSAGES = 20;
+
+    private static final JavaType LIST_TYPE =
+            OttoJson.MAPPER.getTypeFactory().constructCollectionType(List.class, Turn.class);
+
+    private final JsonStore store;
+
+    public ConversationStore(JsonStore store) {
+        this.store = store;
+    }
+
+    /** One message in the conversation, from the user or the assistant. */
+    public record Turn(Role role, String text, Instant at) {
+
+        public enum Role {
+            USER, ASSISTANT
+        }
+    }
+
+    /** The messages the next Ask carries as context. */
+    public List<Turn> window(Instant now) {
+        Instant oldest = now.minus(WINDOW);
+        return newest(all().stream()
+                .filter(turn -> turn.at().isAfter(oldest))
+                .toList());
+    }
+
+    /** Records one exchange: what the user asked and what Otto answered. */
+    public synchronized void record(Instant now, String question, String answer) {
+        List<Turn> turns = new ArrayList<>(all());
+        turns.add(new Turn(Turn.Role.USER, question, now));
+        turns.add(new Turn(Turn.Role.ASSISTANT, answer, now));
+        // The stored document stays bounded by the same cap the window
+        // reads with: nothing beyond it can ever come back.
+        store.write(DOCUMENT, newest(turns));
+    }
+
+    private List<Turn> newest(List<Turn> turns) {
+        return turns.size() <= MAX_MESSAGES
+                ? turns
+                : List.copyOf(turns.subList(turns.size() - MAX_MESSAGES, turns.size()));
+    }
+
+    private List<Turn> all() {
+        return store.<List<Turn>>read(DOCUMENT, LIST_TYPE).orElseGet(List::of);
+    }
+}

--- a/src/main/java/otto/ask/LineupPlanner.java
+++ b/src/main/java/otto/ask/LineupPlanner.java
@@ -150,7 +150,7 @@ public class LineupPlanner {
                     "%s already starts for you this week".formatted(team.name(startId)));
         }
 
-        SlotChoice choice = slotToFree(team, startId, sit);
+        SlotChoice choice = slotToFree(team, startId, now, sit);
         if (choice instanceof SlotChoice.Rejected rejected) {
             return ToolAnswer.unavailable(rejected.reason());
         }
@@ -208,18 +208,32 @@ public class LineupPlanner {
      * The starting slot the incoming player would take: the one whose
      * starter the user named, or the weakest slot his position fits
      * when the user named nobody.
+     *
+     * Picking for the user only ever picks a slot he can still free.
+     * A locked starter cannot come out, so the weakest slot on the
+     * board is the wrong answer when that starter's game has kicked
+     * off; naming him explicitly still prices the swap and says it is
+     * not legal.
      */
-    private SlotChoice slotToFree(UserWeek team, String startId, String sit) {
+    private SlotChoice slotToFree(UserWeek team, String startId, Instant now, String sit) {
         if (sit == null || sit.isBlank()) {
-            return IntStream.range(0, team.slots().size())
-                    .filter(index -> team.slots().get(index).accepts(team.position(startId)))
+            String position = team.position(startId);
+            List<Integer> accepting = IntStream.range(0, team.slots().size())
+                    .filter(index -> team.slots().get(index).accepts(position))
                     .boxed()
+                    .toList();
+            if (accepting.isEmpty()) {
+                return new SlotChoice.Rejected(
+                        "no starting slot of yours accepts a %s".formatted(position));
+            }
+            return accepting.stream()
+                    .filter(index -> !starterLocked(team, index, now))
                     .min(Comparator.comparingDouble(
                             index -> slotPoints(team, team.starterAt(index))))
                     .<SlotChoice>map(SlotChoice.Found::new)
                     .orElseGet(() -> new SlotChoice.Rejected(
-                            "no starting slot of yours accepts a %s"
-                                    .formatted(team.position(startId))));
+                            "every slot that takes a %s has already locked this week"
+                                    .formatted(position)));
         }
 
         List<String> matches = resolve(team, sit);
@@ -277,6 +291,12 @@ public class LineupPlanner {
             team.points(playerId).ifPresent(projected -> points.put(playerId, projected));
         }
         return points;
+    }
+
+    /** True when a slot's starter can no longer be taken out. */
+    private boolean starterLocked(UserWeek team, int index, Instant now) {
+        String starterId = team.starterAt(index);
+        return starterId != null && team.locked(starterId, now);
     }
 
     /** Says so when a player in the swap is a certain zero. */

--- a/src/main/java/otto/ask/LineupPlanner.java
+++ b/src/main/java/otto/ask/LineupPlanner.java
@@ -1,0 +1,386 @@
+package otto.ask;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.IntStream;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import org.springframework.stereotype.Component;
+
+import otto.directory.PlayerHealth;
+import otto.lineup.LineupOptimizer;
+import otto.lineup.Slot;
+
+/**
+ * The deterministic core behind the Ask lane's lineup tools. Every
+ * number here is Java arithmetic over the league's own scoring; the
+ * model only reads what this class computes.
+ *
+ * A slot's points are what the lineup actually scores as set: a starter
+ * who cannot play (ruled out, on bye) or who has no projection counts
+ * zero, so the current and optimal totals compare like for like.
+ * Locked players keep their slots - Sleeper locks a player at kickoff,
+ * bench included - so the optimizer only reshuffles what the user can
+ * still change.
+ */
+@Component
+public class LineupPlanner {
+
+    private static final String NO_WEEK_MATH =
+            "I have no projections or starting slots for this week yet";
+
+    private final LineupOptimizer optimizer;
+
+    public LineupPlanner(LineupOptimizer optimizer) {
+        this.optimizer = optimizer;
+    }
+
+    /** One starting slot and who fills it. */
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public record SlotLine(String slot, String player, String position, String team,
+            String projection, String note) {
+    }
+
+    /** One bench player. */
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public record BenchLine(String player, String position, String team, String health,
+            String projection, String note) {
+    }
+
+    public record RosterStatus(String week, String manager, String startersProjected,
+            List<SlotLine> starters, List<BenchLine> bench) {
+    }
+
+    /** "Start {@code start} over {@code sit}" and what it gains. */
+    public record Swap(String start, String sit, String slot, String gain) {
+    }
+
+    public record LineupPlan(String week, String currentProjected, String optimalProjected,
+            String delta, List<SlotLine> optimal, List<Swap> swaps) {
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public record WhatIf(String week, String start, String sit, String slot,
+            String currentProjected, String projected, String delta, boolean legal,
+            List<String> notes) {
+    }
+
+    public RosterStatus rosterStatus(UserWeek team, Instant now) {
+        List<SlotLine> starters = new ArrayList<>();
+        for (int index = 0; index < team.slots().size(); index++) {
+            starters.add(slotLine(team, now, team.slots().get(index).name(),
+                    team.starterAt(index)));
+        }
+
+        List<BenchLine> bench = team.bench().stream()
+                .map(playerId -> new BenchLine(
+                        team.name(playerId),
+                        team.position(playerId),
+                        team.team(playerId),
+                        team.health(playerId).name(),
+                        team.projection(playerId),
+                        note(team, now, playerId)))
+                .toList();
+
+        return new RosterStatus(
+                team.weekKey().orElse(null),
+                team.roster().ownerName(),
+                points(lineupTotal(team, team.starters())),
+                starters,
+                bench);
+    }
+
+    public ToolAnswer<LineupPlan> recommend(UserWeek team, Instant now) {
+        if (!team.hasLineupMath()) {
+            return ToolAnswer.unavailable(NO_WEEK_MATH);
+        }
+        List<Slot> slots = team.slots();
+        Map<String, Double> movable = movablePoints(team, now);
+        Map<Integer, String> optimal = optimalLineup(team, now, movable);
+
+        double current = lineupTotal(team, team.starters());
+        double best = lineupTotal(team, optimal.values());
+
+        List<SlotLine> lines = new ArrayList<>();
+        for (int index = 0; index < slots.size(); index++) {
+            lines.add(slotLine(team, now, slots.get(index).name(), optimal.get(index)));
+        }
+
+        List<Swap> swaps = optimizer.swaps(team.starters(), optimal.values(), movable).stream()
+                .map(swap -> new Swap(
+                        team.name(swap.starting()),
+                        team.name(swap.sitting()),
+                        slotOf(slots, optimal, swap.starting()),
+                        signed(swap.gain())))
+                .toList();
+
+        return ToolAnswer.of(new LineupPlan(
+                team.weekKey().orElse(null),
+                points(current),
+                points(best),
+                signed(best - current),
+                lines,
+                swaps));
+    }
+
+    /**
+     * Prices one hypothetical change before the user acts. Without a
+     * player to sit, the weakest starter whose slot accepts the
+     * incoming player makes the room - the swap the user would make.
+     */
+    public ToolAnswer<WhatIf> whatIf(UserWeek team, Instant now, String start, String sit) {
+        if (!team.hasLineupMath()) {
+            return ToolAnswer.unavailable(NO_WEEK_MATH);
+        }
+
+        List<String> startMatches = resolve(team, start);
+        if (startMatches.size() != 1) {
+            return ToolAnswer.unavailable(describeNoMatch(team, start, startMatches));
+        }
+        String startId = startMatches.getFirst();
+        if (team.starters().contains(startId)) {
+            return ToolAnswer.unavailable(
+                    "%s already starts for you this week".formatted(team.name(startId)));
+        }
+
+        SlotChoice choice = slotToFree(team, startId, sit);
+        if (choice instanceof SlotChoice.Rejected rejected) {
+            return ToolAnswer.unavailable(rejected.reason());
+        }
+        int slotIndex = ((SlotChoice.Found) choice).index();
+
+        String sitId = team.starterAt(slotIndex);
+        Slot slot = team.slots().get(slotIndex);
+        double current = lineupTotal(team, team.starters());
+        double projected = current - slotPoints(team, sitId) + slotPoints(team, startId);
+
+        // Legal means Sleeper would take the change: the slot accepts
+        // the position and neither player has locked. A bye or ruled-out
+        // player is a legal choice and a certain zero - the notes say so.
+        boolean fits = slot.accepts(team.position(startId));
+        boolean startLocked = team.locked(startId, now);
+        boolean sitLocked = sitId != null && team.locked(sitId, now);
+
+        List<String> notes = new ArrayList<>();
+        if (!fits) {
+            notes.add("Sleeper will not take a %s in the %s slot"
+                    .formatted(team.position(startId), slot.name()));
+        }
+        if (startLocked) {
+            notes.add("%s has already locked this week".formatted(team.name(startId)));
+        }
+        if (sitLocked) {
+            notes.add("%s has already locked this week".formatted(team.name(sitId)));
+        }
+        addZeroNote(team, startId, notes);
+        addZeroNote(team, sitId, notes);
+
+        return ToolAnswer.of(new WhatIf(
+                team.weekKey().orElse(null),
+                team.name(startId),
+                sitId == null ? null : team.name(sitId),
+                slot.name(),
+                points(current),
+                points(projected),
+                signed(projected - current),
+                fits && !startLocked && !sitLocked,
+                notes));
+    }
+
+    /** Which starting slot a what-if would free, or why it cannot. */
+    private sealed interface SlotChoice {
+
+        record Found(int index) implements SlotChoice {
+        }
+
+        record Rejected(String reason) implements SlotChoice {
+        }
+    }
+
+    /**
+     * The starting slot the incoming player would take: the one whose
+     * starter the user named, or the weakest slot his position fits
+     * when the user named nobody.
+     */
+    private SlotChoice slotToFree(UserWeek team, String startId, String sit) {
+        if (sit == null || sit.isBlank()) {
+            return IntStream.range(0, team.slots().size())
+                    .filter(index -> team.slots().get(index).accepts(team.position(startId)))
+                    .boxed()
+                    .min(Comparator.comparingDouble(
+                            index -> slotPoints(team, team.starterAt(index))))
+                    .<SlotChoice>map(SlotChoice.Found::new)
+                    .orElseGet(() -> new SlotChoice.Rejected(
+                            "no starting slot of yours accepts a %s"
+                                    .formatted(team.position(startId))));
+        }
+
+        List<String> matches = resolve(team, sit);
+        if (matches.size() != 1) {
+            return new SlotChoice.Rejected(describeNoMatch(team, sit, matches));
+        }
+        int index = team.starters().indexOf(matches.getFirst());
+        if (index < 0 || index >= team.slots().size()) {
+            return new SlotChoice.Rejected("%s does not start for you this week"
+                    .formatted(team.name(matches.getFirst())));
+        }
+        return new SlotChoice.Found(index);
+    }
+
+    /**
+     * The optimal legal lineup as slot index to player id. Locked
+     * starters keep their slots; the optimizer fills the rest with the
+     * players the user can still move.
+     */
+    private Map<Integer, String> optimalLineup(UserWeek team, Instant now,
+            Map<String, Double> movable) {
+        List<Slot> slots = team.slots();
+
+        Map<Integer, String> fixed = new LinkedHashMap<>();
+        List<Integer> openSlots = new ArrayList<>();
+        for (int index = 0; index < slots.size(); index++) {
+            String playerId = team.starterAt(index);
+            if (playerId != null && team.locked(playerId, now)) {
+                fixed.put(index, playerId);
+            } else {
+                openSlots.add(index);
+            }
+        }
+
+        Map<Integer, String> assigned = optimizer.assign(
+                openSlots.stream().map(slots::get).toList(),
+                movable,
+                team.roster().playerPositions());
+
+        Map<Integer, String> optimal = new LinkedHashMap<>(fixed);
+        assigned.forEach((openIndex, playerId) -> optimal.put(openSlots.get(openIndex), playerId));
+        return optimal;
+    }
+
+    /**
+     * Projected points for every player the user can still start and
+     * still move: able to play this week and not locked.
+     */
+    private Map<String, Double> movablePoints(UserWeek team, Instant now) {
+        Map<String, Double> points = new HashMap<>();
+        for (String playerId : team.roster().players()) {
+            if (!team.canPlay(playerId) || team.locked(playerId, now)) {
+                continue;
+            }
+            team.points(playerId).ifPresent(projected -> points.put(playerId, projected));
+        }
+        return points;
+    }
+
+    /** Says so when a player in the swap is a certain zero. */
+    private void addZeroNote(UserWeek team, String playerId, List<String> notes) {
+        if (playerId == null) {
+            return;
+        }
+        PlayerHealth health = team.health(playerId);
+        if (health.rulesOutPlaying()) {
+            notes.add("%s is %s and scores zero".formatted(team.name(playerId), health));
+        } else if (team.onBye(playerId)) {
+            notes.add("%s is on bye and scores zero".formatted(team.name(playerId)));
+        }
+    }
+
+    private SlotLine slotLine(UserWeek team, Instant now, String slotName, String playerId) {
+        if (playerId == null) {
+            return new SlotLine(slotName, null, null, null, points(0.0), "empty slot");
+        }
+        return new SlotLine(
+                slotName,
+                team.name(playerId),
+                team.position(playerId),
+                team.team(playerId),
+                team.projection(playerId),
+                note(team, now, playerId));
+    }
+
+    /** What stops this player from scoring, or nothing to say. */
+    private String note(UserWeek team, Instant now, String playerId) {
+        PlayerHealth health = team.health(playerId);
+        if (health.rulesOutPlaying()) {
+            return "cannot play: " + health;
+        }
+        if (team.onBye(playerId)) {
+            return "on bye";
+        }
+        if (team.locked(playerId, now)) {
+            return "locked";
+        }
+        if (health.isWorseThan(PlayerHealth.ACTIVE)) {
+            return health.name().toLowerCase(Locale.ROOT);
+        }
+        return null;
+    }
+
+    /** The points this player contributes to a lineup total as set. */
+    private double slotPoints(UserWeek team, String playerId) {
+        if (playerId == null || !team.canPlay(playerId)) {
+            return 0.0;
+        }
+        return team.points(playerId).orElse(0.0);
+    }
+
+    private double lineupTotal(UserWeek team, Iterable<String> playerIds) {
+        double total = 0.0;
+        for (String playerId : playerIds) {
+            total += slotPoints(team, playerId);
+        }
+        return total;
+    }
+
+    private String slotOf(List<Slot> slots, Map<Integer, String> lineup, String playerId) {
+        return lineup.entrySet().stream()
+                .filter(entry -> entry.getValue().equals(playerId))
+                .map(entry -> slots.get(entry.getKey()).name())
+                .findFirst()
+                .orElse(null);
+    }
+
+    /**
+     * Matches what the user typed against their own roster: a player
+     * id, or any player whose name contains the text. Ambiguity is
+     * never resolved by guessing - the caller asks which one.
+     */
+    private List<String> resolve(UserWeek team, String reference) {
+        if (reference == null || reference.isBlank()) {
+            return List.of();
+        }
+        String needle = reference.trim();
+        if (team.roster().players().contains(needle)) {
+            return List.of(needle);
+        }
+        String lowered = needle.toLowerCase(Locale.ROOT);
+        return team.roster().players().stream()
+                .filter(playerId -> Optional.ofNullable(team.roster().playerNames().get(playerId))
+                        .map(playerName -> playerName.toLowerCase(Locale.ROOT).contains(lowered))
+                        .orElse(false))
+                .toList();
+    }
+
+    private String describeNoMatch(UserWeek team, String reference, List<String> matches) {
+        if (matches.isEmpty()) {
+            return "no player on your roster matches \"%s\"".formatted(reference);
+        }
+        return "\"%s\" matches more than one of your players: %s".formatted(reference,
+                matches.stream().map(team::name).toList());
+    }
+
+    private static String points(double value) {
+        return String.format(Locale.ROOT, "%.1f", value);
+    }
+
+    private static String signed(double value) {
+        return String.format(Locale.ROOT, "%+.1f", value);
+    }
+}

--- a/src/main/java/otto/ask/ToolAnswer.java
+++ b/src/main/java/otto/ask/ToolAnswer.java
@@ -1,0 +1,23 @@
+package otto.ask;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+/**
+ * What every Ask tool hands back to the model: the computed facts, or
+ * the reason it cannot answer. A tool never guesses and never returns
+ * an empty shell, so the model can say plainly what the assistant
+ * cannot see instead of filling the gap itself.
+ *
+ * @param <T> the computed fact shape this tool returns
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record ToolAnswer<T>(T facts, String unavailable) {
+
+    public static <T> ToolAnswer<T> of(T facts) {
+        return new ToolAnswer<>(facts, null);
+    }
+
+    public static <T> ToolAnswer<T> unavailable(String reason) {
+        return new ToolAnswer<>(null, reason);
+    }
+}

--- a/src/main/java/otto/ask/UserWeek.java
+++ b/src/main/java/otto/ask/UserWeek.java
@@ -1,0 +1,104 @@
+package otto.ask;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+import otto.check.WeekFacts;
+import otto.directory.PlayerHealth;
+import otto.lineup.ProjectionTable;
+import otto.lineup.Slot;
+import otto.sleeper.SleeperAdapter;
+import otto.snapshot.RosterSnapshot;
+
+/**
+ * What an Ask tool needs to answer a question about the user's team:
+ * the league document, the user's roster from the latest Snapshot, and
+ * this week's facts.
+ *
+ * It answers about one player at a time, so callers ask it rather than
+ * walking into the roster and the week themselves. Every source fails
+ * soft, so each answer states what it does when its source is missing.
+ */
+public record UserWeek(
+        SleeperAdapter.League league,
+        RosterSnapshot roster,
+        WeekFacts week) {
+
+    /** Sleeper writes an unfilled starting slot as player id "0". */
+    private static final String EMPTY_SLOT = "0";
+
+    public List<Slot> slots() {
+        return week.startingSlots();
+    }
+
+    public Optional<String> weekKey() {
+        return week.weekKey();
+    }
+
+    /** True when the week carries the projections and slots the math needs. */
+    public boolean hasLineupMath() {
+        return week.projections().isPresent() && !week.startingSlots().isEmpty();
+    }
+
+    public String name(String playerId) {
+        return roster.playerNames().getOrDefault(playerId, playerId);
+    }
+
+    public String position(String playerId) {
+        return roster.playerPositions().get(playerId);
+    }
+
+    public String team(String playerId) {
+        return roster.playerTeams().get(playerId);
+    }
+
+    /** An unlisted player counts as healthy: only a designation flags one. */
+    public PlayerHealth health(String playerId) {
+        PlayerHealth health = roster.playerHealth().get(playerId);
+        return health == null ? PlayerHealth.ACTIVE : health;
+    }
+
+    /** True when the player can take the field this week. */
+    public boolean canPlay(String playerId) {
+        return week.canPlay(roster, playerId);
+    }
+
+    /** True once the player's game has kicked off; without games, never. */
+    public boolean locked(String playerId, Instant now) {
+        return week.games().map(games -> games.locked(team(playerId), now)).orElse(false);
+    }
+
+    public boolean onBye(String playerId) {
+        return week.games().map(games -> games.onBye(team(playerId))).orElse(false);
+    }
+
+    public Optional<Double> points(String playerId) {
+        return week.projections().flatMap(table -> table.points(playerId, position(playerId)));
+    }
+
+    public String projection(String playerId) {
+        return week.projections()
+                .map(table -> table.display(playerId, position(playerId)))
+                .orElse(ProjectionTable.NO_PROJECTION);
+    }
+
+    /** The starter in a starting slot, or null when the slot is empty. */
+    public String starterAt(int index) {
+        if (index < 0 || index >= roster.starters().size()) {
+            return null;
+        }
+        String playerId = roster.starters().get(index);
+        return playerId == null || EMPTY_SLOT.equals(playerId) ? null : playerId;
+    }
+
+    public List<String> starters() {
+        return roster.starters();
+    }
+
+    public List<String> bench() {
+        return roster.players().stream()
+                .filter(playerId -> !roster.starters().contains(playerId))
+                .toList();
+    }
+}

--- a/src/main/java/otto/ask/UserWeekLoader.java
+++ b/src/main/java/otto/ask/UserWeekLoader.java
@@ -1,0 +1,60 @@
+package otto.ask;
+
+import java.util.Optional;
+
+import org.springframework.stereotype.Component;
+
+import otto.alerts.SelfReportService;
+import otto.check.WeekFactsBuilder;
+import otto.sleeper.SleeperAdapter;
+import otto.sleeper.SourceResult;
+import otto.snapshot.RosterSnapshot;
+import otto.snapshot.Snapshot;
+import otto.snapshot.SnapshotStore;
+
+/**
+ * Loads what the Ask tools read: the league document plus the user's
+ * roster from the latest Snapshot. Asks never poll a new Snapshot -
+ * the Check owns that cadence, and answering from the stored one keeps
+ * a burst of questions off Sleeper's rate limit.
+ */
+@Component
+public class UserWeekLoader {
+
+    private final SleeperAdapter sleeper;
+    private final SnapshotStore snapshotStore;
+    private final WeekFactsBuilder weekFactsBuilder;
+    private final SelfReportService selfReport;
+
+    public UserWeekLoader(SleeperAdapter sleeper, SnapshotStore snapshotStore,
+            WeekFactsBuilder weekFactsBuilder, SelfReportService selfReport) {
+        this.sleeper = sleeper;
+        this.snapshotStore = snapshotStore;
+        this.weekFactsBuilder = weekFactsBuilder;
+        this.selfReport = selfReport;
+    }
+
+    /** The league document alone, for questions that need no roster. */
+    public SourceResult<SleeperAdapter.League> league() {
+        SourceResult<SleeperAdapter.League> league = sleeper.league();
+        selfReport.reportIfUnavailable(league);
+        return league;
+    }
+
+    public SourceResult<UserWeek> load() {
+        return league().flatMap(league -> userRoster()
+                .<SourceResult<UserWeek>>map(roster -> new SourceResult.Ok<>(
+                        new UserWeek(league, roster, weekFactsBuilder.build(league))))
+                .orElseGet(() -> new SourceResult.Unavailable<>("snapshot",
+                        "no Snapshot stored yet, so I cannot see your roster; "
+                                + "the next Check builds one")));
+    }
+
+    private Optional<RosterSnapshot> userRoster() {
+        return snapshotStore.current()
+                .map(Snapshot::rosters)
+                .flatMap(rosters -> rosters.stream()
+                        .filter(RosterSnapshot::userRoster)
+                        .findFirst());
+    }
+}

--- a/src/main/java/otto/check/CheckRunner.java
+++ b/src/main/java/otto/check/CheckRunner.java
@@ -5,7 +5,6 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 
 import org.springframework.stereotype.Component;
@@ -18,9 +17,6 @@ import otto.directory.PlayerDirectoryService;
 import otto.directory.PlayerDirectoryStore;
 import otto.events.Event;
 import otto.events.EventLog;
-import otto.lineup.GameWeek;
-import otto.lineup.ProjectionTable;
-import otto.lineup.Slot;
 import otto.sleeper.SleeperAdapter;
 import otto.sleeper.SourceResult;
 import otto.snapshot.LeagueStatus;
@@ -42,6 +38,7 @@ public class CheckRunner {
     private final SnapshotBuilder snapshotBuilder;
     private final SnapshotDiffer snapshotDiffer;
     private final SnapshotStore snapshotStore;
+    private final WeekFactsBuilder weekFactsBuilder;
     private final LastCheckStore stateStore;
     private final EventLog eventLog;
     private final AlertService alertService;
@@ -53,7 +50,8 @@ public class CheckRunner {
     public CheckRunner(PlayerDirectoryService directoryService,
             PlayerDirectoryStore directoryStore, SleeperAdapter sleeper,
             SnapshotBuilder snapshotBuilder, SnapshotDiffer snapshotDiffer,
-            SnapshotStore snapshotStore, LastCheckStore stateStore, EventLog eventLog,
+            SnapshotStore snapshotStore, WeekFactsBuilder weekFactsBuilder,
+            LastCheckStore stateStore, EventLog eventLog,
             AlertService alertService, VerificationService verificationService,
             SelfReportService selfReport, Clock clock, OttoProperties properties) {
         this.directoryService = directoryService;
@@ -62,6 +60,7 @@ public class CheckRunner {
         this.snapshotBuilder = snapshotBuilder;
         this.snapshotDiffer = snapshotDiffer;
         this.snapshotStore = snapshotStore;
+        this.weekFactsBuilder = weekFactsBuilder;
         this.stateStore = stateStore;
         this.eventLog = eventLog;
         this.alertService = alertService;
@@ -89,7 +88,7 @@ public class CheckRunner {
         Optional<Snapshot> inSeason = stage.snapshot()
                 .filter(snapshot -> snapshot.leagueStatus() == LeagueStatus.IN_SEASON);
         if (inSeason.isPresent()) {
-            WeekFacts week = weekFacts(stage.league());
+            WeekFacts week = weekFactsBuilder.build(stage.league());
             alerts.addAll(alertService.process(inSeason.get(), week));
             verificationService.verify(inSeason.get(), week, now);
         }
@@ -116,9 +115,9 @@ public class CheckRunner {
         SourceResult<SleeperAdapter.League> league = sleeper.league();
         SourceResult<List<SleeperAdapter.Roster>> rosters = sleeper.rosters();
         SourceResult<List<SleeperAdapter.LeagueUser>> users = sleeper.users();
-        reportIfUnavailable(league);
-        reportIfUnavailable(rosters);
-        reportIfUnavailable(users);
+        selfReport.reportIfUnavailable(league);
+        selfReport.reportIfUnavailable(rosters);
+        selfReport.reportIfUnavailable(users);
         if (!(league instanceof SourceResult.Ok<SleeperAdapter.League> leagueOk)
                 || !(rosters instanceof SourceResult.Ok<List<SleeperAdapter.Roster>> rostersOk)
                 || !(users instanceof SourceResult.Ok<List<SleeperAdapter.LeagueUser>> usersOk)) {
@@ -138,56 +137,4 @@ public class CheckRunner {
         return new SnapshotStage(Optional.of(current), leagueOk.value(), appended);
     }
 
-    /**
-     * Assembles the week-scoped detection inputs: the NFL week, the
-     * projected stat lines priced in league scoring, the starting
-     * slots, and the week's games. Every failed source self-reports
-     * once and leaves its part empty - detectors skip what is missing.
-     */
-    private WeekFacts weekFacts(SleeperAdapter.League league) {
-        List<Slot> slots = Slot.startingSlots(league.rosterPositions());
-        if (slots.isEmpty() || league.scoringSettings().isEmpty()) {
-            selfReport.report("sleeper:league-settings",
-                    "league document lacks roster_positions or scoring_settings");
-        }
-
-        SourceResult<SleeperAdapter.NflState> state = sleeper.nflState();
-        reportIfUnavailable(state);
-        if (!(state instanceof SourceResult.Ok<SleeperAdapter.NflState> stateOk)) {
-            return WeekFacts.unavailable(slots);
-        }
-        String season = stateOk.value().season();
-        int week = stateOk.value().week();
-
-        // A projection table without scoring settings could only answer
-        // "no projection available"; stay empty so detectors skip instead.
-        SourceResult<Map<String, Map<String, Double>>> projections =
-                sleeper.projections(season, week);
-        reportIfUnavailable(projections);
-        Optional<ProjectionTable> projectionTable = !league.scoringSettings().isEmpty()
-                && projections
-                        instanceof SourceResult.Ok<Map<String, Map<String, Double>>> projectionsOk
-                                ? Optional.of(new ProjectionTable(
-                                        league.scoringSettings(), projectionsOk.value()))
-                                : Optional.empty();
-
-        SourceResult<List<SleeperAdapter.Game>> games = sleeper.games(season, week);
-        reportIfUnavailable(games);
-        Optional<GameWeek> gameWeek =
-                games instanceof SourceResult.Ok<List<SleeperAdapter.Game>> gamesOk
-                        ? Optional.of(GameWeek.of(gamesOk.value()))
-                        : Optional.empty();
-
-        return new WeekFacts(
-                Optional.of("%s-w%d".formatted(season, week)),
-                projectionTable,
-                slots,
-                gameWeek);
-    }
-
-    private void reportIfUnavailable(SourceResult<?> result) {
-        if (result instanceof SourceResult.Unavailable<?> unavailable) {
-            selfReport.report(unavailable.source(), unavailable.reason());
-        }
-    }
 }

--- a/src/main/java/otto/check/WeekFactsBuilder.java
+++ b/src/main/java/otto/check/WeekFactsBuilder.java
@@ -1,0 +1,77 @@
+package otto.check;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.springframework.stereotype.Component;
+
+import otto.alerts.SelfReportService;
+import otto.lineup.GameWeek;
+import otto.lineup.ProjectionTable;
+import otto.lineup.Slot;
+import otto.sleeper.SleeperAdapter;
+import otto.sleeper.SourceResult;
+
+/**
+ * Assembles the week-scoped facts: the NFL week, the projected stat
+ * lines priced in league scoring, the starting slots, and the week's
+ * games. Every failed source self-reports once and leaves its part
+ * empty - readers skip what is missing instead of guessing.
+ *
+ * A Check builds these for Alert detection; the Ask tools build the
+ * same facts to answer questions, so both lanes read one week the same
+ * way.
+ */
+@Component
+public class WeekFactsBuilder {
+
+    private final SleeperAdapter sleeper;
+    private final SelfReportService selfReport;
+
+    public WeekFactsBuilder(SleeperAdapter sleeper, SelfReportService selfReport) {
+        this.sleeper = sleeper;
+        this.selfReport = selfReport;
+    }
+
+    public WeekFacts build(SleeperAdapter.League league) {
+        List<Slot> slots = Slot.startingSlots(league.rosterPositions());
+        if (slots.isEmpty() || league.scoringSettings().isEmpty()) {
+            selfReport.report("sleeper:league-settings",
+                    "league document lacks roster_positions or scoring_settings");
+        }
+
+        SourceResult<SleeperAdapter.NflState> state = sleeper.nflState();
+        selfReport.reportIfUnavailable(state);
+        if (!(state instanceof SourceResult.Ok<SleeperAdapter.NflState> stateOk)) {
+            return WeekFacts.unavailable(slots);
+        }
+        String season = stateOk.value().season();
+        int week = stateOk.value().week();
+
+        // A projection table without scoring settings could only answer
+        // "no projection available"; stay empty so readers skip instead.
+        SourceResult<Map<String, Map<String, Double>>> projections =
+                sleeper.projections(season, week);
+        selfReport.reportIfUnavailable(projections);
+        Optional<ProjectionTable> projectionTable = !league.scoringSettings().isEmpty()
+                && projections
+                        instanceof SourceResult.Ok<Map<String, Map<String, Double>>> projectionsOk
+                                ? Optional.of(new ProjectionTable(
+                                        league.scoringSettings(), projectionsOk.value()))
+                                : Optional.empty();
+
+        SourceResult<List<SleeperAdapter.Game>> games = sleeper.games(season, week);
+        selfReport.reportIfUnavailable(games);
+        Optional<GameWeek> gameWeek =
+                games instanceof SourceResult.Ok<List<SleeperAdapter.Game>> gamesOk
+                        ? Optional.of(GameWeek.of(gamesOk.value()))
+                        : Optional.empty();
+
+        return new WeekFacts(
+                Optional.of("%s-w%d".formatted(season, week)),
+                projectionTable,
+                slots,
+                gameWeek);
+    }
+}

--- a/src/main/java/otto/lineup/LineupOptimizer.java
+++ b/src/main/java/otto/lineup/LineupOptimizer.java
@@ -1,5 +1,7 @@
 package otto.lineup;
 
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -49,5 +51,50 @@ public class LineupOptimizer {
                     });
         }
         return assignment;
+    }
+
+    /**
+     * Reads a reshuffle as concrete "start A over B" pairs.
+     *
+     * Both sides sort strongest first, so a multi-player reshuffle
+     * pairs the best entering player with the best leaving one.
+     * Pairing best against worst would inflate one pair's gain and
+     * describe a swap nobody would name that way.
+     *
+     * @param current the player ids in the lineup now
+     * @param optimal the player ids the optimizer chose
+     * @param points projected points per movable player; a player
+     *        absent from it cannot be moved, so neither side of a pair
+     *        is ever built from one. A caller may pin players outside
+     *        this map into the optimal lineup - a locked starter keeps
+     *        their slot - and pairing against them would price a swap
+     *        the user cannot make.
+     */
+    public List<LineupSwap> swaps(Collection<String> current, Collection<String> optimal,
+            Map<String, Double> points) {
+        Set<String> currentIds = new HashSet<>(current);
+        Set<String> optimalIds = new HashSet<>(optimal);
+        Comparator<String> strongestFirst = Comparator
+                .comparingDouble((String playerId) -> points.get(playerId))
+                .reversed();
+        List<String> entering = optimalIds.stream()
+                .filter(points::containsKey)
+                .filter(playerId -> !currentIds.contains(playerId))
+                .sorted(strongestFirst)
+                .toList();
+        List<String> leaving = currentIds.stream()
+                .filter(points::containsKey)
+                .filter(playerId -> !optimalIds.contains(playerId))
+                .sorted(strongestFirst)
+                .toList();
+
+        List<LineupSwap> swaps = new ArrayList<>();
+        int pairs = Math.min(entering.size(), leaving.size());
+        for (int pair = 0; pair < pairs; pair++) {
+            String in = entering.get(pair);
+            String out = leaving.get(pair);
+            swaps.add(new LineupSwap(in, out, points.get(in) - points.get(out)));
+        }
+        return swaps;
     }
 }

--- a/src/main/java/otto/lineup/LineupSwap.java
+++ b/src/main/java/otto/lineup/LineupSwap.java
@@ -1,0 +1,9 @@
+package otto.lineup;
+
+/**
+ * One entering-for-leaving pair from a lineup reshuffle: start
+ * {@code starting} in place of {@code sitting} for {@code gain}
+ * projected points.
+ */
+public record LineupSwap(String starting, String sitting, double gain) {
+}

--- a/src/main/java/otto/telegram/TelegramWebhook.java
+++ b/src/main/java/otto/telegram/TelegramWebhook.java
@@ -13,6 +13,7 @@ import org.springframework.stereotype.Component;
 
 import otto.OttoProperties;
 import otto.alerts.AlertActions;
+import otto.ask.AskService;
 import otto.storage.OttoJson;
 
 /**
@@ -31,13 +32,17 @@ public class TelegramWebhook {
     private static final Pattern TAP = Pattern.compile("(done|ignore|mute):(\\d{1,18})");
 
     private final String webhookSecret;
+    private final String chatId;
     private final AlertActions alertActions;
+    private final AskService ask;
     private final TelegramClient telegram;
 
     public TelegramWebhook(OttoProperties properties, AlertActions alertActions,
-            TelegramClient telegram) {
+            AskService ask, TelegramClient telegram) {
         this.webhookSecret = properties.telegram().webhookSecret();
+        this.chatId = properties.telegram().chatId();
         this.alertActions = alertActions;
+        this.ask = ask;
         this.telegram = telegram;
     }
 
@@ -50,9 +55,24 @@ public class TelegramWebhook {
             JsonNode callback = update.path("callback_query");
             if (!callback.isMissingNode()) {
                 answerTap(callback);
+                return;
             }
+            answerAsk(update.path("message"));
         });
         return WebhookResult.OK;
+    }
+
+    /**
+     * Free text goes to the Ask loop and its reply back to the chat.
+     * Only the one chat the assistant serves is answered; anything else
+     * that reaches this endpoint is dropped without a model call.
+     */
+    private void answerAsk(JsonNode message) {
+        String text = message.path("text").asText("");
+        if (text.isBlank() || !chatId.equals(message.path("chat").path("id").asText(""))) {
+            return;
+        }
+        telegram.sendMessage(ask.answer(text));
     }
 
     private void answerTap(JsonNode callback) {

--- a/src/test/java/otto/AskScenarioTest.java
+++ b/src/test/java/otto/AskScenarioTest.java
@@ -1,6 +1,7 @@
 package otto;
 
 import java.time.Duration;
+import java.time.Instant;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -135,6 +136,30 @@ class AskScenarioTest extends WireSeamTest {
                 .withRequestBody(containing("144.5"))
                 .withRequestBody(containing("-0.5"))
                 .withRequestBody(containing("Travis Kelce")));
+    }
+
+    @Test
+    void aWhatIfPicksOnlyASlotTheUserCanStillFree() {
+        snapshotWithABenchEdge();
+        OutboundStubs.telegramOk(telegram);
+        OutboundStubs.llmCallsToolThenPhrases(llm, "whatif_lineup",
+                "{\"start\":\"Josh Jacobs\"}", "Jacobs for Love gains you 1.5.");
+
+        // Sunday afternoon: the 17:00 UTC games have kicked off, so
+        // every RB-capable slot has locked except SUPER_FLEX, where
+        // Love (GB, Monday) still sits.
+        clock.set(Instant.parse("2026-09-20T18:00:00Z"));
+
+        ask("what if I start Jacobs?");
+
+        // Cook projects lowest of the slots an RB fits, but his game is
+        // underway and Sleeper will not take him out. Love is the
+        // weakest starter the user can still move: 145.0 - 15.0 + 16.5.
+        llm.verify(1, postRequestedFor(urlPathMatching(OutboundStubs.CHAT_COMPLETIONS_PATH))
+                .withRequestBody(containing("Jordan Love"))
+                .withRequestBody(containing("146.5"))
+                .withRequestBody(containing("+1.5"))
+                .withRequestBody(notContaining("James Cook")));
     }
 
     @Test

--- a/src/test/java/otto/AskScenarioTest.java
+++ b/src/test/java/otto/AskScenarioTest.java
@@ -1,0 +1,285 @@
+package otto;
+
+import java.time.Duration;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import otto.check.CheckRunner;
+import otto.harness.OutboundStubs;
+import otto.harness.SleeperStubs;
+import otto.harness.WireSeamTest;
+import otto.telegram.TelegramWebhook;
+import otto.telegram.WebhookResult;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.containing;
+import static com.github.tomakehurst.wiremock.client.WireMock.notContaining;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The Ask loop: free text from the user's chat routes through the Lane A
+ * agent loop over the deterministic tools, and the model narrates what
+ * the tools computed. Java owns every number in these scenarios; the
+ * canned tool-call sequences make the routing deterministic.
+ *
+ * The fixture roster starts Mahomes 22.0, McCaffrey 18.0, Bijan 16.0,
+ * Jefferson 19.0, Lamb 17.0, Kelce 11.0, Wilson 14.0, Cook 13.0 and
+ * Love 15.0 for 145.0 projected points. Jacobs (16.5) sits on the bench
+ * over Cook (13.0), so the optimal legal lineup projects 148.5.
+ */
+class AskScenarioTest extends WireSeamTest {
+
+    private static final String LINEUP_PHRASE = "Start Jacobs over Cook: +3.5 points.";
+
+    @Autowired
+    private CheckRunner checkRunner;
+
+    @Autowired
+    private TelegramWebhook webhook;
+
+    /**
+     * Ask tools read the latest Snapshot, so a Check runs first. The
+     * edge Alert it sends is not what these scenarios observe: the LLM
+     * and Telegram journals reset before the Ask.
+     */
+    private void snapshotWithABenchEdge() {
+        SleeperStubs.healthyInSeason(sleeper);
+        SleeperStubs.stubJson(sleeper, SleeperStubs.PROJECTIONS_PATH,
+                "sleeper/projections-edge.json", "projections-v1");
+        OutboundStubs.telegramOk(telegram);
+        OutboundStubs.llmPhrases(llm, "An alert about the bench edge.");
+
+        checkRunner.runCheck();
+
+        llm.resetAll();
+        telegram.resetRequests();
+    }
+
+    private void ask(String text) {
+        assertThat(webhook.handle(WEBHOOK_SECRET, OutboundStubs.textMessage(text)))
+                .isEqualTo(WebhookResult.OK);
+    }
+
+    @Test
+    void aLineupQuestionIsAnsweredFromTheRecommendLineupTool() {
+        snapshotWithABenchEdge();
+        OutboundStubs.telegramOk(telegram);
+        OutboundStubs.llmCallsToolThenPhrases(llm, "recommend_lineup", "{}", LINEUP_PHRASE);
+
+        ask("lineup");
+
+        // The user gets the model's narration, not raw tool JSON.
+        telegram.verify(1, postRequestedFor(urlEqualTo(OutboundStubs.SEND_MESSAGE_PATH))
+                .withRequestBody(containing(LINEUP_PHRASE)));
+
+        // Two model calls: route to the tool, then narrate its result.
+        // The numbers reach the model from Java, never from the model.
+        llm.verify(2, postRequestedFor(urlPathMatching(OutboundStubs.CHAT_COMPLETIONS_PATH)));
+        llm.verify(1, postRequestedFor(urlPathMatching(OutboundStubs.CHAT_COMPLETIONS_PATH))
+                .withRequestBody(containing("145.0"))
+                .withRequestBody(containing("148.5"))
+                .withRequestBody(containing("+3.5"))
+                .withRequestBody(containing("Josh Jacobs"))
+                .withRequestBody(containing("James Cook"))
+                .withRequestBody(notContaining("99.9")));
+    }
+
+    @Test
+    void theModelIsOfferedEveryLaneATool() {
+        snapshotWithABenchEdge();
+        OutboundStubs.telegramOk(telegram);
+        OutboundStubs.llmPhrases(llm, "Anything you like.");
+
+        ask("what should I do this week?");
+
+        llm.verify(1, postRequestedFor(urlPathMatching(OutboundStubs.CHAT_COMPLETIONS_PATH))
+                .withRequestBody(containing("get_roster_status"))
+                .withRequestBody(containing("get_league_settings"))
+                .withRequestBody(containing("recommend_lineup"))
+                .withRequestBody(containing("whatif_lineup")));
+    }
+
+    @Test
+    void aWhatIfQuestionProjectsTheSwapBeforeTheUserActs() {
+        snapshotWithABenchEdge();
+        OutboundStubs.telegramOk(telegram);
+        OutboundStubs.llmCallsToolThenPhrases(llm, "whatif_lineup",
+                "{\"start\":\"Josh Jacobs\",\"sit\":\"James Cook\"}",
+                "That swap gains you 3.5 points.");
+
+        ask("what if I start Jacobs over Cook?");
+
+        llm.verify(1, postRequestedFor(urlPathMatching(OutboundStubs.CHAT_COMPLETIONS_PATH))
+                .withRequestBody(containing("145.0"))
+                .withRequestBody(containing("148.5"))
+                .withRequestBody(containing("+3.5")));
+    }
+
+    @Test
+    void aWhatIfThatCostsPointsSaysSo() {
+        snapshotWithABenchEdge();
+        OutboundStubs.telegramOk(telegram);
+        OutboundStubs.llmCallsToolThenPhrases(llm, "whatif_lineup",
+                "{\"start\":\"Dallas Goedert\"}",
+                "Goedert would cost you half a point.");
+
+        ask("what if I start Goedert?");
+
+        // Goedert (10.5) can only replace Kelce (11.0) in the TE slot,
+        // the weakest starter whose slot he fits: 148.5 stays out of
+        // reach and the lineup loses 0.5.
+        llm.verify(1, postRequestedFor(urlPathMatching(OutboundStubs.CHAT_COMPLETIONS_PATH))
+                .withRequestBody(containing("144.5"))
+                .withRequestBody(containing("-0.5"))
+                .withRequestBody(containing("Travis Kelce")));
+    }
+
+    @Test
+    void rosterStatusReadsTheStoredSnapshot() {
+        snapshotWithABenchEdge();
+        OutboundStubs.telegramOk(telegram);
+        OutboundStubs.llmCallsToolThenPhrases(llm, "get_roster_status", "{}",
+                "Your starters are healthy.");
+
+        ask("how does my roster look?");
+
+        llm.verify(1, postRequestedFor(urlPathMatching(OutboundStubs.CHAT_COMPLETIONS_PATH))
+                .withRequestBody(containing("Patrick Mahomes"))
+                .withRequestBody(containing("SUPER_FLEX"))
+                .withRequestBody(containing("Josh Jacobs")));
+    }
+
+    @Test
+    void leagueSettingsComeFromTheLeagueDocument() {
+        snapshotWithABenchEdge();
+        OutboundStubs.telegramOk(telegram);
+        OutboundStubs.llmCallsToolThenPhrases(llm, "get_league_settings", "{}",
+                "Superflex, full PPR with a TE premium.");
+
+        ask("what are my league settings?");
+
+        llm.verify(1, postRequestedFor(urlPathMatching(OutboundStubs.CHAT_COMPLETIONS_PATH))
+                .withRequestBody(containing("Raising Canes Demon"))
+                .withRequestBody(containing("SUPER_FLEX"))
+                .withRequestBody(containing("bonus_rec_te")));
+    }
+
+    @Test
+    void aToolWithoutASnapshotSaysWhatItCannotSee() {
+        SleeperStubs.healthyInSeason(sleeper);
+        OutboundStubs.telegramOk(telegram);
+        OutboundStubs.llmCallsToolThenPhrases(llm, "get_roster_status", "{}",
+                "I have not built a snapshot of your roster yet.");
+
+        ask("how does my roster look?");
+
+        // No Check has run, so the tool reports the blind spot instead
+        // of guessing; silence never masquerades as certainty.
+        llm.verify(1, postRequestedFor(urlPathMatching(OutboundStubs.CHAT_COMPLETIONS_PATH))
+                .withRequestBody(containing("no Snapshot stored yet")));
+        telegram.verify(1, postRequestedFor(urlEqualTo(OutboundStubs.SEND_MESSAGE_PATH)));
+    }
+
+    @Test
+    void theConversationWindowKeepsTheLastTwentyMessages() {
+        snapshotWithABenchEdge();
+        OutboundStubs.telegramOk(telegram);
+        OutboundStubs.llmPhrases(llm, "Noted.");
+
+        for (int turn = 1; turn <= 12; turn++) {
+            ask("ask-%02d".formatted(turn));
+        }
+
+        // Each Ask adds two messages. By the twelfth, the window has
+        // rolled past the first exchange but still carries the second.
+        llm.verify(0, postRequestedFor(urlPathMatching(OutboundStubs.CHAT_COMPLETIONS_PATH))
+                .withRequestBody(containing("ask-01"))
+                .withRequestBody(containing("ask-12")));
+        llm.verify(1, postRequestedFor(urlPathMatching(OutboundStubs.CHAT_COMPLETIONS_PATH))
+                .withRequestBody(containing("ask-02"))
+                .withRequestBody(containing("ask-12")));
+    }
+
+    @Test
+    void theConversationWindowDropsMessagesOlderThanADay() {
+        snapshotWithABenchEdge();
+        OutboundStubs.telegramOk(telegram);
+        OutboundStubs.llmPhrases(llm, "Noted.");
+
+        ask("ask-yesterday");
+        clock.advance(Duration.ofHours(25));
+        ask("ask-today");
+
+        llm.verify(0, postRequestedFor(urlPathMatching(OutboundStubs.CHAT_COMPLETIONS_PATH))
+                .withRequestBody(containing("ask-yesterday"))
+                .withRequestBody(containing("ask-today")));
+    }
+
+    @Test
+    void repliesAreShortByDefaultAndDeeperWhenTheUserAsksWhy() {
+        snapshotWithABenchEdge();
+        OutboundStubs.telegramOk(telegram);
+        OutboundStubs.llmPhrases(llm, "Noted.");
+
+        ask("lineup");
+        ask("why?");
+        ask("tell me more");
+        ask("I want more points from my flex this year");
+
+        // Short by default; "why" and a short "more" open the answer up.
+        // A long question that merely says "more" is a fresh question.
+        llm.verify(2, postRequestedFor(urlPathMatching(OutboundStubs.CHAT_COMPLETIONS_PATH))
+                .withRequestBody(containing("2 to 5 lines"))
+                .withRequestBody(notContaining("Give the full reasoning")));
+        llm.verify(2, postRequestedFor(urlPathMatching(OutboundStubs.CHAT_COMPLETIONS_PATH))
+                .withRequestBody(containing("Give the full reasoning")));
+    }
+
+    @Test
+    void anOutageReplyNeverEntersTheConversationWindow() {
+        snapshotWithABenchEdge();
+        OutboundStubs.telegramOk(telegram);
+        OutboundStubs.llmRefuses(llm);
+
+        ask("ask-during-outage");
+
+        llm.resetAll();
+        OutboundStubs.llmPhrases(llm, "Noted.");
+        ask("ask-after-outage");
+
+        // A spell of outages must not evict the real conversation, and
+        // the model must never read its own outage text as a past answer.
+        llm.verify(0, postRequestedFor(urlPathMatching(OutboundStubs.CHAT_COMPLETIONS_PATH))
+                .withRequestBody(containing("ask-during-outage")));
+        llm.verify(0, postRequestedFor(urlPathMatching(OutboundStubs.CHAT_COMPLETIONS_PATH))
+                .withRequestBody(containing("cannot reach")));
+    }
+
+    @Test
+    void aModelOutageStillGetsAnHonestReply() {
+        snapshotWithABenchEdge();
+        OutboundStubs.telegramOk(telegram);
+        OutboundStubs.llmRefuses(llm);
+
+        ask("lineup");
+
+        telegram.verify(1, postRequestedFor(urlEqualTo(OutboundStubs.SEND_MESSAGE_PATH))
+                .withRequestBody(containing("cannot reach")));
+    }
+
+    @Test
+    void aMessageFromAnotherChatIsIgnored() {
+        snapshotWithABenchEdge();
+        OutboundStubs.telegramOk(telegram);
+        OutboundStubs.llmPhrases(llm, "Noted.");
+
+        assertThat(webhook.handle(WEBHOOK_SECRET, OutboundStubs.textMessage(9999, "lineup")))
+                .isEqualTo(WebhookResult.OK);
+
+        llm.verify(0, postRequestedFor(urlPathMatching(OutboundStubs.CHAT_COMPLETIONS_PATH)));
+        telegram.verify(0, postRequestedFor(urlEqualTo(OutboundStubs.SEND_MESSAGE_PATH)));
+    }
+}

--- a/src/test/java/otto/harness/OutboundStubs.java
+++ b/src/test/java/otto/harness/OutboundStubs.java
@@ -2,6 +2,8 @@ package otto.harness;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder;
+import com.github.tomakehurst.wiremock.stubbing.Scenario;
 
 import otto.storage.OttoJson;
 
@@ -16,6 +18,10 @@ public final class OutboundStubs {
     public static final String SEND_MESSAGE_PATH = "/bottest-bot-token/sendMessage";
     public static final String ANSWER_CALLBACK_PATH = "/bottest-bot-token/answerCallbackQuery";
     public static final String CHAT_COMPLETIONS_PATH = "(/v1)?/chat/completions";
+
+    /** The canned Lane A run: one tool call, then the narration. */
+    private static final String TOOL_RUN = "lane-a-tool-run";
+    private static final String TOOL_CALLED = "tool-called";
 
     private OutboundStubs() {
     }
@@ -58,8 +64,67 @@ public final class OutboundStubs {
                 """.formatted(jsonString(callbackData));
     }
 
+    /** One free-text Ask from the user's chat, as Telegram posts it. */
+    public static String textMessage(String text) {
+        return textMessage(WireSeamTest.USER_CHAT_ID, text);
+    }
+
+    /** The same update from any chat, to prove the chat gate works. */
+    public static String textMessage(long chatId, String text) {
+        return """
+                {
+                  "update_id": 300,
+                  "message": {
+                    "message_id": 11,
+                    "from": {"id": %d, "is_bot": false, "first_name": "Brandon"},
+                    "chat": {"id": %d, "type": "private"},
+                    "text": %s
+                  }
+                }
+                """.formatted(chatId, chatId, jsonString(text));
+    }
+
     public static void llmPhrases(WireMockServer llm, String phrase) {
-        String body = """
+        llm.stubFor(post(urlPathMatching(CHAT_COMPLETIONS_PATH))
+                .willReturn(completion(contentBody(phrase))));
+    }
+
+    /**
+     * The canned tool-call sequence that makes Lane A routing
+     * deterministic: the first call answers with the tool call, the
+     * second - the one carrying the tool result - answers with the
+     * narration. No test spends tokens.
+     */
+    public static void llmCallsToolThenPhrases(WireMockServer llm, String tool,
+            String arguments, String phrase) {
+        llm.stubFor(post(urlPathMatching(CHAT_COMPLETIONS_PATH))
+                .inScenario(TOOL_RUN)
+                .whenScenarioStateIs(Scenario.STARTED)
+                .willReturn(completion(toolCallBody(tool, arguments)))
+                .willSetStateTo(TOOL_CALLED));
+        llm.stubFor(post(urlPathMatching(CHAT_COMPLETIONS_PATH))
+                .inScenario(TOOL_RUN)
+                .whenScenarioStateIs(TOOL_CALLED)
+                .willReturn(completion(contentBody(phrase))));
+    }
+
+    /** The model is unreachable: a request error the SDK does not retry. */
+    public static void llmRefuses(WireMockServer llm) {
+        llm.stubFor(post(urlPathMatching(CHAT_COMPLETIONS_PATH)).willReturn(aResponse()
+                .withStatus(400)
+                .withHeader("Content-Type", "application/json")
+                .withBody("{\"error\":{\"message\":\"bad request\",\"type\":\"invalid_request_error\"}}")));
+    }
+
+    private static ResponseDefinitionBuilder completion(String body) {
+        return aResponse()
+                .withStatus(200)
+                .withHeader("Content-Type", "application/json")
+                .withBody(body);
+    }
+
+    private static String contentBody(String phrase) {
+        return """
                 {
                   "id": "chatcmpl-fixture",
                   "object": "chat.completion",
@@ -75,9 +140,34 @@ public final class OutboundStubs {
                   "usage": {"prompt_tokens": 120, "completion_tokens": 25, "total_tokens": 145}
                 }
                 """.formatted(jsonString(phrase));
-        llm.stubFor(post(urlPathMatching(CHAT_COMPLETIONS_PATH)).willReturn(aResponse()
-                .withStatus(200)
-                .withHeader("Content-Type", "application/json")
-                .withBody(body)));
+    }
+
+    private static String toolCallBody(String tool, String arguments) {
+        return """
+                {
+                  "id": "chatcmpl-fixture-tool",
+                  "object": "chat.completion",
+                  "created": 1757000000,
+                  "model": "gpt-5.6-luna",
+                  "choices": [
+                    {
+                      "index": 0,
+                      "message": {
+                        "role": "assistant",
+                        "content": null,
+                        "tool_calls": [
+                          {
+                            "id": "call-1",
+                            "type": "function",
+                            "function": {"name": %s, "arguments": %s}
+                          }
+                        ]
+                      },
+                      "finish_reason": "tool_calls"
+                    }
+                  ],
+                  "usage": {"prompt_tokens": 120, "completion_tokens": 25, "total_tokens": 145}
+                }
+                """.formatted(jsonString(tool), jsonString(arguments));
     }
 }

--- a/src/test/java/otto/harness/WireSeamTest.java
+++ b/src/test/java/otto/harness/WireSeamTest.java
@@ -35,6 +35,9 @@ public abstract class WireSeamTest {
     /** The secret token Telegram must echo back on every webhook call. */
     public static final String WEBHOOK_SECRET = "test-webhook-secret";
 
+    /** The one chat the assistant serves. */
+    public static final long USER_CHAT_ID = 4242;
+
     protected static final WireMockServer sleeper = newServer();
     protected static final WireMockServer telegram = newServer();
     protected static final WireMockServer llm = newServer();
@@ -60,7 +63,7 @@ public abstract class WireSeamTest {
         registry.add("otto.sleeper.base-url", sleeper::baseUrl);
         registry.add("otto.telegram.base-url", telegram::baseUrl);
         registry.add("otto.telegram.bot-token", () -> "test-bot-token");
-        registry.add("otto.telegram.chat-id", () -> "4242");
+        registry.add("otto.telegram.chat-id", () -> String.valueOf(USER_CHAT_ID));
         registry.add("otto.telegram.webhook-secret", () -> WEBHOOK_SECRET);
         registry.add("otto.storage-dir", () -> storageDir.toString());
         registry.add("spring.ai.openai.base-url", llm::baseUrl);


### PR DESCRIPTION
Closes #13.

## What this does

Free text to the bot now routes through the Lane A tool-calling agent loop. The model picks a tool, deterministic Java computes the facts, and the model words the answer. It never computes a number itself.

The first four of the twelve tools land here:

| Tool | Answers |
|---|---|
| `get_roster_status` | every starting slot, who fills it, projections, and what stops each player scoring |
| `get_league_settings` | scoring settings, starting slots, league status |
| `recommend_lineup` | the optimal legal lineup with the point delta against the lineup set now, plus the start-over-sit swaps |
| `whatif_lineup` | one hypothetical change priced before the user acts |

Conversation context is a rolling window of the last day, capped at twenty messages. Replies run 2 to 5 lines by default; "why" and "more" open them up. Only the configured chat reaches the loop, so a stray update can never spend tokens.

## Shared rules, defined once

Three extractions so the Check lane and the Ask lane cannot drift apart:

- `WeekFactsBuilder`, out of `CheckRunner` - a Check and an Ask read one week the same way, with the same fail-soft self-reports.
- `LineupOptimizer.swaps` and `LineupSwap`, out of `BenchEdgeDetector` - both lanes read a reshuffle as the same start-over-sit pairs.
- `SelfReportService.reportIfUnavailable` - every caller reports a broken source identically.

## Decisions recorded

ADR-0002 closes the semantic gaps the ticket left open: Asks read the stored Snapshot rather than building one, locked players keep their slots in the optimal lineup, a lineup total is what the lineup scores as set, "legal" in a what-if means Sleeper would take it, and an outage reply never enters the conversation window.

## Testing

Full suite: 57 tests, 0 failures. The 15 new Ask scenarios run at the wire seam with canned tool-call sequences from the fake LLM server, so routing is deterministic and no test spends tokens. The scenarios were written first and confirmed failing before the implementation existed.

The fixture arithmetic was verified independently of the tests: the roster's current lineup projects 145.0 and the optimal 148.5, a 3.5-point gain from Jacobs replacing Cook, under the league's own scoring. Sleeper's pre-computed `pts_ppr` is poison in the fixtures and asserted absent.

## Known gap

One PRD line is deliberately not implemented: "a tool fetches live only when its data is older than its cadence interval." An Ask still reads the league document and week facts as conditional GETs against the ETag cache the Check fills - 304s, not payloads. Implementing it needs a per-source fetch clock the Check must not share, since the Check's whole job is to poll every minute. That belongs with the remaining eight tools. The gap is recorded in ADR-0002 rather than left silent; issue #13's own acceptance criteria are all met.