### PR TITLE
fix: keep the teams nobody has claimed yet (#26)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,11 @@
+# From BotFather, when you register the bot.
+TELEGRAM_BOT_TOKEN=
+
+# Your own chat with the bot.
+TELEGRAM_CHAT_ID=
+
+# The shared secret you register with setWebhook.
+TELEGRAM_WEBHOOK_SECRET=
+
+# The LLM key
+OPENAI_API_KEY=

--- a/README.md
+++ b/README.md
@@ -17,13 +17,17 @@ The tests boot the real Spring context and invoke the two entry points - the Che
 
 ## Run a Check loop locally
 
-Set the secrets, then start with the `local` profile:
+Copy `.env.example` to `.env` and fill it in. Nothing loads that file by itself, so put it into the environment and then start with the `local` profile:
 
 ```sh
-export TELEGRAM_BOT_TOKEN=...   # from BotFather
-export TELEGRAM_CHAT_ID=...     # your chat with the bot
-export OPENAI_API_KEY=...
+set -a; source .env; set +a
 SPRING_PROFILES_ACTIVE=local mvn spring-boot:run
+```
+
+To read the chat id, message the bot once, then ask Telegram who wrote:
+
+```sh
+curl -s "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/getUpdates" | jq '.result[].message.chat.id'
 ```
 
 The loop runs one Check every 60 seconds. In a pre-draft league the cadence gate inside the Check drops this to one full Check per day, and no roster Alerts fire.

--- a/src/main/java/otto/sleeper/SleeperAdapter.java
+++ b/src/main/java/otto/sleeper/SleeperAdapter.java
@@ -73,7 +73,13 @@ public class SleeperAdapter {
     public record Game(String homeTeam, String awayTeam, Instant startTime, String status) {
     }
 
-    public record Roster(int rosterId, String ownerId, List<String> players, List<String> starters) {
+    /**
+     * One team in the league. A team nobody has claimed yet has no
+     * owner, which is how every team reads before a draft fills the
+     * league up.
+     */
+    public record Roster(int rosterId, Optional<String> ownerId, List<String> players,
+            List<String> starters) {
     }
 
     public record LeagueUser(String userId, String displayName) {
@@ -170,12 +176,18 @@ public class SleeperAdapter {
             }
             List<Roster> rosters = new ArrayList<>();
             for (JsonNode roster : body) {
-                if (!roster.hasNonNull("roster_id") || !roster.hasNonNull("owner_id")) {
-                    return schemaDrift(path, "roster_id or owner_id missing");
+                // Only roster_id is required: it is how Otto tells one
+                // team from another. An absent owner means nobody has
+                // claimed the team yet, which is a real state Sleeper
+                // reports for most teams before a draft.
+                if (!roster.hasNonNull("roster_id")) {
+                    return schemaDrift(path, "roster_id missing");
                 }
                 rosters.add(new Roster(
                         roster.get("roster_id").asInt(),
-                        roster.get("owner_id").asText(),
+                        Optional.ofNullable(roster.get("owner_id"))
+                                .filter(JsonNode::isTextual)
+                                .map(JsonNode::asText),
                         textList(roster.path("players")),
                         textList(roster.path("starters"))));
             }

--- a/src/main/java/otto/snapshot/SnapshotBuilder.java
+++ b/src/main/java/otto/snapshot/SnapshotBuilder.java
@@ -37,7 +37,7 @@ public class SnapshotBuilder {
 
     private RosterSnapshot toRosterSnapshot(SleeperAdapter.Roster roster,
             Map<String, String> namesByUserId, Optional<PlayerDirectory> directory) {
-        String ownerName = namesByUserId.get(roster.ownerId());
+        String ownerName = roster.ownerId().map(namesByUserId::get).orElse(null);
         Map<String, PlayerHealth> health = new HashMap<>();
         Map<String, String> names = new HashMap<>();
         Map<String, String> positions = new HashMap<>();
@@ -53,7 +53,7 @@ public class SnapshotBuilder {
                 }));
         return new RosterSnapshot(
                 roster.rosterId(),
-                roster.ownerId(),
+                roster.ownerId().orElse(null),
                 ownerName,
                 username.equals(ownerName),
                 roster.starters(),

--- a/src/test/java/otto/SnapshotScenarioTest.java
+++ b/src/test/java/otto/SnapshotScenarioTest.java
@@ -53,6 +53,55 @@ class SnapshotScenarioTest extends WireSeamTest {
         assertThat(mine.playerTeams().get("4034")).isEqualTo("SF");
     }
 
+    /**
+     * Before a draft most teams have nobody in them. Sleeper answers
+     * with a null owner for each one, which is a real state and not a
+     * broken answer: dropping the whole roster list over it left Otto
+     * blind to the league it was watching.
+     */
+    @Test
+    void aCheckKeepsTheTeamsNobodyHasClaimedYet() {
+        SleeperStubs.preDraftWithUnclaimedTeams(sleeper);
+
+        checkRunner.runCheck();
+
+        Snapshot current = snapshotStore.current().orElseThrow();
+        assertThat(current.leagueStatus()).isEqualTo(LeagueStatus.PRE_DRAFT);
+        assertThat(current.rosters()).hasSize(4);
+        assertThat(current.rosters()).extracting(RosterSnapshot::rosterId)
+                .containsExactly(1, 2, 3, 4);
+
+        RosterSnapshot unclaimed = current.rosters().stream()
+                .filter(roster -> roster.rosterId() == 3)
+                .findFirst().orElseThrow();
+        assertThat(unclaimed.ownerId()).isNull();
+        assertThat(unclaimed.ownerName()).isNull();
+        assertThat(unclaimed.userRoster()).isFalse();
+        assertThat(unclaimed.players()).isEmpty();
+
+        RosterSnapshot mine = current.rosters().stream()
+                .filter(RosterSnapshot::userRoster)
+                .findFirst().orElseThrow();
+        assertThat(mine.ownerName()).isEqualTo("SenorMustache");
+
+        assertThat(eventLog.all()).noneMatch(event ->
+                event.type() == EventType.SOURCE_UNAVAILABLE);
+    }
+
+    /**
+     * The league status only reaches the stored state through the
+     * Snapshot, and the pre-draft cadence gate reads it from there. A
+     * rosters read that fails leaves the status unknown, so Otto keeps
+     * polling every minute instead of once a day.
+     */
+    @Test
+    void aPreDraftCheckSlowsTheNextOneDownToTheDailyCadence() {
+        SleeperStubs.preDraftWithUnclaimedTeams(sleeper);
+
+        checkRunner.runCheck();
+        assertThat(checkRunner.runCheck().skipped()).isTrue();
+    }
+
     @Test
     void aSecondCheckPollsWithConditionalGetsAndKeepsThePreviousSnapshot() {
         SleeperStubs.healthyInSeason(sleeper);

--- a/src/test/java/otto/harness/SleeperStubs.java
+++ b/src/test/java/otto/harness/SleeperStubs.java
@@ -33,6 +33,19 @@ public final class SleeperStubs {
     }
 
     /**
+     * A league before its draft. Teams nobody has claimed yet carry no
+     * owner, and no roster holds players. Sleeper really answers this
+     * way, so the fixture keeps the nulls rather than tidying them.
+     */
+    public static void preDraftWithUnclaimedTeams(WireMockServer sleeper) {
+        stubJson(sleeper, PLAYERS_PATH, "sleeper/players-nfl.json", "players-v1");
+        stubJson(sleeper, LEAGUE_PATH, "sleeper/league-pre-draft.json", "league-v1");
+        stubJson(sleeper, ROSTERS_PATH, "sleeper/rosters-pre-draft.json", "rosters-v1");
+        stubJson(sleeper, USERS_PATH, "sleeper/users.json", "users-v1");
+        stubJson(sleeper, STATE_PATH, "sleeper/state-nfl.json", "state-v1");
+    }
+
+    /**
      * Per-player news. The limit rides in the query string and the news
      * feed is never cached, so the stub matches on the path alone.
      */

--- a/src/test/resources/fixtures/sleeper/rosters-pre-draft.json
+++ b/src/test/resources/fixtures/sleeper/rosters-pre-draft.json
@@ -1,0 +1,54 @@
+[
+  {
+    "roster_id": 1,
+    "owner_id": "777001",
+    "league_id": "1389748403805650944",
+    "players": null,
+    "starters": null,
+    "reserve": null,
+    "settings": {
+      "wins": 0,
+      "losses": 0,
+      "waiver_budget_used": 0
+    }
+  },
+  {
+    "roster_id": 2,
+    "owner_id": "777002",
+    "league_id": "1389748403805650944",
+    "players": null,
+    "starters": null,
+    "reserve": null,
+    "settings": {
+      "wins": 0,
+      "losses": 0,
+      "waiver_budget_used": 0
+    }
+  },
+  {
+    "roster_id": 3,
+    "owner_id": null,
+    "league_id": "1389748403805650944",
+    "players": null,
+    "starters": null,
+    "reserve": null,
+    "settings": {
+      "wins": 0,
+      "losses": 0,
+      "waiver_budget_used": 0
+    }
+  },
+  {
+    "roster_id": 4,
+    "owner_id": null,
+    "league_id": "1389748403805650944",
+    "players": null,
+    "starters": null,
+    "reserve": null,
+    "settings": {
+      "wins": 0,
+      "losses": 0,
+      "waiver_budget_used": 0
+    }
+  }
+]


### PR DESCRIPTION
Closes #26.

Otto could not build a Snapshot of the live league. Found by running the local Check loop against league `1389748403805650944` on 2026-08-08.

## The bug

`SleeperAdapter.rosters()` required an owner on every roster and reported schema drift when one was absent:

```java
if (!roster.hasNonNull("roster_id") || !roster.hasNonNull("owner_id")) {
    return schemaDrift(path, "roster_id or owner_id missing");
}
```

Sleeper returned all 12 teams, each with a `roster_id`. Nine had `owner_id: null`, because nobody had claimed them before the draft. One absent field threw away all 12.

It cost two things:

- **No Snapshot.** With no Snapshot there is no Snapshot Diff, so no Alert can fire, and an Ask about the roster answers that Otto cannot see it.
- **No pre-draft cadence.** The league status only reaches the stored state through the Snapshot, so `CheckRunner.withinPreDraftCadence` never saw `PRE_DRAFT`. Otto polled Sleeper every 60 seconds instead of once a day. Sleeper's Freshness Ceiling means those extra polls returned nothing new.

## The fix

An absent owner is a real state, not a broken answer.

- Only `roster_id` is required. That field is how Otto tells one team from another, so it stays schema drift.
- `Roster.ownerId` became `Optional<String>`, so the boundary says out loud that a team can have no owner.
- `SnapshotBuilder` skips the owner-name lookup when there is no owner. The team still enters the Snapshot.

Keeping the unclaimed teams is deliberate: #15 is league awareness and it needs all 12.

## Verification

Both tests were written first and failed for the right reasons: no Snapshot was built, and the second Check was not skipped. The fixture keeps the nulls exactly as Sleeper sends them, `players` included.

Full suite: **74 tests, 0 failures, 0 errors.**

Confirmed live against the real league, before and after:

| | Before | After |
|---|---|---|
| League status | `UNKNOWN` | `PRE_DRAFT` |
| Snapshot | none built | built |
| New source-unavailable events | 1 | 0 |
| Full Checks in ~3.5 min | 9 | 1 |

## Also in this PR

A `.env.example`. `.gitignore` already excluded `.env`, but nothing recorded which variables belong in it. Nothing loads `.env` by itself, since Spring Boot does not read it and the project has no dotenv dependency, so the README now shows how to put it into the environment and how to read the chat id from Telegram.