### PR TITLE
feat: reach the Ask loop from the local profile (#28)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,7 +4,8 @@ TELEGRAM_BOT_TOKEN=
 # Your own chat with the bot.
 TELEGRAM_CHAT_ID=
 
-# The shared secret you register with setWebhook.
+# The shared secret you register with setWebhook. Any value will do
+# locally: the long poll hands it to the same seam the webhook calls.
 TELEGRAM_WEBHOOK_SECRET=
 
 # The LLM key

--- a/README.md
+++ b/README.md
@@ -15,13 +15,14 @@ mvn test
 
 The tests boot the real Spring context and invoke the two entry points - the Check and the Telegram webhook - directly. Stub HTTP servers play Sleeper, Telegram, and the LLM with recorded fixtures, including canned tool-call sequences for the Ask loop. No test touches the network or spends tokens.
 
-## Run a Check loop locally
+## Run Otto locally
 
-Copy `.env.example` to `.env` and fill it in. Nothing loads that file by itself, so put it into the environment and then start with the `local` profile:
+Copy `.env.example` to `.env` and fill it in.
+
+Locally, Otto reads your messages with `getUpdates`, and Telegram refuses that call for a bot that has a webhook registered. So clear the webhook before anything else, or both commands below answer 409:
 
 ```sh
-set -a; source .env; set +a
-SPRING_PROFILES_ACTIVE=local mvn spring-boot:run
+curl -s "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/deleteWebhook"
 ```
 
 To read the chat id, message the bot once, then ask Telegram who wrote:
@@ -30,8 +31,17 @@ To read the chat id, message the bot once, then ask Telegram who wrote:
 curl -s "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/getUpdates" | jq '.result[].message.chat.id'
 ```
 
-The loop runs one Check every 60 seconds. In a pre-draft league the cadence gate inside the Check drops this to one full Check per day, and no roster Alerts fire.
+Nothing loads `.env` by itself, so put it into the environment and then start with the `local` profile:
+
+```sh
+set -a; source .env; set +a
+SPRING_PROFILES_ACTIVE=local mvn spring-boot:run
+```
+
+The `local` profile runs one Check every 60 seconds and reads your Telegram messages. In a pre-draft league the cadence gate inside the Check drops this to one full Check per day, and no roster Alerts fire.
 
 ## Ask the bot
 
 Text the bot in plain language and the Ask loop answers. A tool-calling agent routes the question to deterministic tools - the roster, the league settings, the optimal lineup, and what-if swaps - and words what they computed; it never computes a number itself. Replies run 2 to 5 lines; reply "why" or "more" for the full reasoning. The loop answers only the configured chat, and it reads the Snapshot the last Check stored.
+
+Deployed, Telegram posts each message to a webhook. Locally there is no address for it to post to, so the `local` profile asks Telegram for its own messages instead - a `getUpdates` long poll that hands each one to the same code the webhook calls. Buttons work the same way, so Done, Ignore, and Mute answer from the phone. Otto registers nothing with Telegram, which is why the webhook is cleared by hand above.

--- a/docs/adr/0007-local-telegram-delivery.md
+++ b/docs/adr/0007-local-telegram-delivery.md
@@ -1,0 +1,78 @@
+# ADR-0007: Local delivery of Telegram updates
+
+Status: accepted (2026-08-08, issue #28)
+
+The Ask loop had no front door. `TelegramWebhook.handle` was called
+only by tests, and the real caller - the Lambda function URL - lands in
+the last slice of the build. This ADR records how the operator's own
+machine reaches the same seam, and what that costs.
+
+## The local profile long-polls; it serves no endpoint
+
+Telegram offers two ways in: it posts each update to a webhook, or the
+bot asks for its updates with `getUpdates`. A laptop has no address
+Telegram can post to, so a webhook would need an HTTP server, a tunnel
+in front of it, and a `setWebhook` registration.
+
+Long polling needs none of the three. It keeps `spring-boot-starter`
+without the web starter, so the deployable stays free of an embedded
+server under SnapStart; it registers nothing with Telegram, so a local
+run can never rewrite the deployed assistant's front door; and it adds
+no runtime dependency at all.
+
+The cost is that `getUpdates` carries no secret-token header. The
+driver therefore hands the configured secret straight to the seam. That
+is honest for a local-only path: the header check guards a public URL
+against the internet, and this call has no public URL. The check itself
+keeps its own wire-test cover.
+
+## One reader at a time, and the operator picks it
+
+Telegram gives a bot one delivery path, not two: with a webhook
+registered, `getUpdates` answers 409. The driver does not settle that
+for itself. It calls neither `setWebhook` nor `deleteWebhook`, because
+the registration it would rewrite is the deployed assistant's own front
+door - and a local run that quietly took delivery of the user's
+messages, or that exited leaving the webhook deleted, would be a worse
+failure than a poll that does not start.
+
+So the handoff belongs to the operator, and the README carries it:
+clear the webhook by hand before a local run. The 409 is reported with
+that instruction rather than swallowed. Once the deployed webhook is
+live, reading messages locally at the same time needs a second bot,
+which is the only way Telegram gives to have two readers.
+
+## The driver polls on a thread of its own
+
+`LocalCheckLoop` and `LocalNflverseJobs` are `@Scheduled` beans, and
+Spring's default scheduler has one thread. A poll blocks for up to 25
+seconds, which is a quarter of the Check's whole period, so a scheduled
+poll would push the Check off its minute. The driver runs its own
+virtual thread instead, starts on `ApplicationReadyEvent`, and stops
+with the context.
+
+## An update is confirmed before it is answered
+
+Telegram keeps offering an update until a later poll confirms it, so
+"already answered" has to be a decision the driver makes, not a
+promise the wire keeps. The driver holds a watermark - the highest
+update id it has taken - and stores it, so a restart cannot replay the
+last unconfirmed update.
+
+The watermark is written before the update is answered, not after. A
+crash between the two then costs one reply, where the other order would
+put the same question to the model again and text the user twice. A
+failure while answering is caught for the same reason: one bad update
+is dropped rather than offered again on every poll for ever.
+
+## The driver gates the chat, not only the seam
+
+ADR-0002 recorded that only the configured chat reaches the Ask loop. A
+button tap does not pass that gate: it carries a callback id and an
+alert id, and the seam acts on the alert. Nothing reaches the Ask loop,
+but a stray tap could still record a user action.
+
+So the driver applies the gate to every update it takes, taps included,
+and reads `callback_query.message.chat` with the sender as the fallback
+Telegram uses for old messages. A dropped update is still confirmed -
+otherwise the poll would hand it back for ever.

--- a/src/main/java/otto/telegram/LocalTelegramLoop.java
+++ b/src/main/java/otto/telegram/LocalTelegramLoop.java
@@ -1,0 +1,287 @@
+package otto.telegram;
+
+import java.time.Duration;
+import java.util.Optional;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import jakarta.annotation.PreDestroy;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.annotation.Profile;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestClient;
+
+import otto.OttoProperties;
+import otto.http.OutboundHttp;
+import otto.storage.JsonStore;
+import otto.storage.OttoJson;
+
+/**
+ * Local stand-in for Telegram's webhook delivery. The deployed app is
+ * reached at a Lambda function URL; a laptop has no such address, so
+ * under the local profile Otto asks Telegram for its own updates - the
+ * getUpdates long poll - and hands each one to
+ * {@link TelegramWebhook#handle}, the seam the function URL also calls.
+ *
+ * <p>Long polling registers nothing with Telegram and serves no port of
+ * its own, so it never rewrites the deployed assistant's front door and
+ * puts no HTTP server into the deployable. Telegram delivers to a
+ * webhook or to getUpdates and never to both, so a bot that has a
+ * webhook registered answers 409 here until the operator clears it.
+ * getUpdates carries no secret-token header, so the driver hands the
+ * configured secret straight to the seam.
+ */
+@Component
+@Profile("local")
+public class LocalTelegramLoop {
+
+    private static final Logger log = LoggerFactory.getLogger(LocalTelegramLoop.class);
+
+    /** How long Telegram holds a poll open when it has nothing to give. */
+    private static final Duration LONG_POLL = Duration.ofSeconds(25);
+
+    /** The read timeout must outlast the long poll, or every poll fails. */
+    private static final Duration READ_TIMEOUT = LONG_POLL.plusSeconds(10);
+
+    /** The pause after a failed poll, so an outage cannot spin the loop. */
+    private static final Duration BACKOFF = Duration.ofSeconds(5);
+
+    /**
+     * The pause between polls. Telegram holds an empty poll open for the
+     * long-poll window, so this normally costs nothing; it is here so a
+     * host that answers at once cannot turn the loop into a flood.
+     */
+    private static final Duration IDLE = Duration.ofSeconds(1);
+
+    /** How long a stop waits for the poll in flight to end. */
+    private static final Duration SHUTDOWN_WAIT = Duration.ofSeconds(2);
+
+    /** Free text and button taps are all the assistant answers. */
+    private static final String ALLOWED_UPDATES = "[\"message\",\"callback_query\"]";
+
+    private static final String DOCUMENT = "telegram-updates";
+
+    private final RestClient http;
+    private final String botToken;
+    private final String chatId;
+    private final String webhookSecret;
+    private final TelegramWebhook webhook;
+    private final JsonStore store;
+
+    private volatile boolean stopped;
+    private volatile Thread poller;
+    private volatile long lastUpdateId;
+
+    public LocalTelegramLoop(OttoProperties properties, TelegramWebhook webhook, JsonStore store) {
+        this.http = RestClient.builder()
+                .baseUrl(properties.telegram().baseUrl())
+                .requestFactory(OutboundHttp.requestFactory(READ_TIMEOUT))
+                .build();
+        this.botToken = properties.telegram().botToken();
+        this.chatId = properties.telegram().chatId();
+        this.webhookSecret = properties.telegram().webhookSecret();
+        this.webhook = webhook;
+        this.store = store;
+        this.lastUpdateId = store.read(DOCUMENT, Watermark.class)
+                .map(Watermark::lastUpdateId)
+                .orElse(0L);
+    }
+
+    /**
+     * Polling starts once the context is up. It runs on a thread of its
+     * own, because a poll blocks for half a minute and the scheduler
+     * that drives the Check has one thread to give.
+     */
+    @EventListener(ApplicationReadyEvent.class)
+    public synchronized void start() {
+        if (botToken.isBlank() || chatId.isBlank() || webhookSecret.isBlank()) {
+            log.warn("Telegram polling is off: set TELEGRAM_BOT_TOKEN, TELEGRAM_CHAT_ID"
+                    + " and TELEGRAM_WEBHOOK_SECRET to reach the Ask loop");
+            return;
+        }
+        if (poller != null) {
+            return;
+        }
+        stopped = false;
+        poller = Thread.ofVirtual().name("telegram-long-poll").start(this::pollUntilStopped);
+        log.info("Telegram polling started: the bot answers chat {}", chatId);
+    }
+
+    /**
+     * Stopping waits for the poll in flight, so no answer can arrive
+     * after the context that owns the driver has gone. The wait is
+     * bounded, so the stopped flag - not the wait - is what keeps a
+     * late-returning poll from answering anything.
+     */
+    @PreDestroy
+    public synchronized void stop() {
+        stopped = true;
+        Thread thread = poller;
+        poller = null;
+        if (thread == null) {
+            return;
+        }
+        thread.interrupt();
+        try {
+            thread.join(SHUTDOWN_WAIT);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    /**
+     * One poll: read the updates Telegram holds and hand each one on.
+     * Public so a test can drive a single poll without the thread.
+     *
+     * @return true when Telegram answered, false when the wire failed
+     */
+    public boolean poll() {
+        Optional<JsonNode> waiting = fetchUpdates();
+        if (waiting.isEmpty()) {
+            return false;
+        }
+        for (JsonNode update : waiting.get()) {
+            if (!dispatch(update)) {
+                break;
+            }
+        }
+        return true;
+    }
+
+    private void pollUntilStopped() {
+        while (!stopped) {
+            pause(poll() ? IDLE : BACKOFF);
+        }
+    }
+
+    private void pause(Duration duration) {
+        try {
+            Thread.sleep(duration);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            stopped = true;
+        }
+    }
+
+    /**
+     * An update Telegram has given us is answered at most once. The
+     * driver confirms it before it answers it, never after: a crash
+     * between the two costs one reply, where the other order would ask
+     * the model the same question again and text the user twice. A
+     * failure while answering is caught here for the same reason, so one
+     * bad update cannot wedge the loop by coming back for ever.
+     *
+     * @return false when the rest of the batch must wait for a later
+     *         poll: the driver is stopping, or the watermark did not store
+     */
+    private boolean dispatch(JsonNode update) {
+        if (stopped) {
+            return false;
+        }
+        long updateId = update.path("update_id").asLong(0);
+        if (updateId <= lastUpdateId) {
+            log.debug("Update {} was answered already", updateId);
+            return true;
+        }
+        if (!confirm(updateId)) {
+            return false;
+        }
+        if (!fromConfiguredChat(update)) {
+            log.info("Dropped update {}: it is not from the chat the assistant serves", updateId);
+            return true;
+        }
+        try {
+            if (webhook.handle(webhookSecret, update.toString()) != WebhookResult.OK) {
+                log.warn("Update {} was refused: the configured webhook secret is not"
+                        + " the one the seam holds", updateId);
+            }
+        } catch (Exception e) {
+            log.warn("Update {} was dropped: {}: {}", updateId,
+                    e.getClass().getSimpleName(), redactToken(e.getMessage()));
+        }
+        return true;
+    }
+
+    /**
+     * The watermark is stored before the driver holds it, so an update
+     * counts as confirmed only once the store has taken it. Telegram's
+     * own offset stops it offering a confirmed update again while the
+     * driver runs, but a driver that came up with no memory would be
+     * offered the last unconfirmed update a second time.
+     *
+     * @return false when the watermark did not store, which leaves this
+     *         update and the ones behind it for a later poll
+     */
+    private boolean confirm(long updateId) {
+        try {
+            store.write(DOCUMENT, new Watermark(updateId));
+        } catch (RuntimeException e) {
+            log.warn("Update {} is left for a later poll: the watermark did not store: {}",
+                    updateId, e.getMessage());
+            return false;
+        }
+        lastUpdateId = updateId;
+        return true;
+    }
+
+    /**
+     * Only the one chat the assistant serves is read. The seam already
+     * drops free text from anywhere else, but a button tap reaches the
+     * Alert actions without passing that gate, so the driver gates both.
+     */
+    private boolean fromConfiguredChat(JsonNode update) {
+        JsonNode tap = update.path("callback_query");
+        if (tap.isMissingNode()) {
+            return chatId.equals(update.path("message").path("chat").path("id").asText(""));
+        }
+        String chat = tap.path("message").path("chat").path("id").asText("");
+        return chatId.equals(chat.isEmpty() ? tap.path("from").path("id").asText("") : chat);
+    }
+
+    private Optional<JsonNode> fetchUpdates() {
+        try {
+            String body = http.get()
+                    .uri(uri -> {
+                        uri.path("/bot{token}/getUpdates")
+                                .queryParam("timeout", LONG_POLL.toSeconds())
+                                .queryParam("allowed_updates", ALLOWED_UPDATES);
+                        if (lastUpdateId > 0) {
+                            uri.queryParam("offset", lastUpdateId + 1);
+                        }
+                        return uri.build(botToken);
+                    })
+                    .retrieve()
+                    .body(String.class);
+            JsonNode answer = OttoJson.MAPPER.readTree(body == null ? "" : body);
+            if (!answer.path("ok").asBoolean(false)) {
+                log.warn("Telegram refused getUpdates: {}",
+                        answer.path("description").asText("no detail"));
+                return Optional.empty();
+            }
+            return Optional.of(answer.path("result"));
+        } catch (HttpClientErrorException.Conflict e) {
+            log.warn("Telegram answers getUpdates with 409 while the bot has a webhook."
+                    + " Clear it with deleteWebhook to read messages locally.");
+            return Optional.empty();
+        } catch (Exception e) {
+            log.warn("Telegram getUpdates failed: {}: {}",
+                    e.getClass().getSimpleName(), redactToken(e.getMessage()));
+            return Optional.empty();
+        }
+    }
+
+    /** An I/O failure message carries the request URI, and so the token. */
+    private String redactToken(String message) {
+        if (message == null) {
+            return "no detail";
+        }
+        return botToken.isBlank() ? message : message.replace(botToken, "***");
+    }
+
+    /** The last update Telegram has given us, as it is stored. */
+    public record Watermark(long lastUpdateId) {
+    }
+}

--- a/src/test/java/otto/LocalPollingScenarioTest.java
+++ b/src/test/java/otto/LocalPollingScenarioTest.java
@@ -1,0 +1,222 @@
+package otto;
+
+import java.time.Duration;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+
+import otto.check.CheckRunner;
+import otto.events.Event;
+import otto.events.EventLog;
+import otto.events.EventType;
+import otto.harness.OutboundStubs;
+import otto.harness.SleeperStubs;
+import otto.harness.WireSeamTest;
+import otto.storage.JsonStore;
+import otto.telegram.LocalTelegramLoop;
+import otto.telegram.TelegramWebhook;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.containing;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.matchingJsonPath;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The local front door. A laptop has no address Telegram can post to,
+ * so under the local profile Otto asks Telegram for its own updates and
+ * hands each one to the webhook seam the deployed function URL calls.
+ * The driver is built here by hand rather than by the profile, so a
+ * poll happens when the test says so and never on a thread of its own.
+ */
+class LocalPollingScenarioTest extends WireSeamTest {
+
+    private static final String ANSWER = "Start Jacobs over Cook: +3.5 points.";
+
+    @Autowired
+    private OttoProperties properties;
+
+    @Autowired
+    private TelegramWebhook webhook;
+
+    @Autowired
+    private JsonStore store;
+
+    @Autowired
+    private CheckRunner checkRunner;
+
+    @Autowired
+    private EventLog eventLog;
+
+    @Autowired
+    private ApplicationContext context;
+
+    private LocalTelegramLoop loop;
+
+    @BeforeEach
+    void buildTheDriver() {
+        loop = newLoop();
+    }
+
+    @AfterEach
+    void stopTheDriver() {
+        loop.stop();
+    }
+
+    /** A driver as the local profile would build it, on a cold start. */
+    private LocalTelegramLoop newLoop() {
+        return new LocalTelegramLoop(properties, webhook, store);
+    }
+
+    /** Telegram holds one free-text Ask from the user's chat. */
+    private void telegramHoldsAnAsk() {
+        SleeperStubs.healthyInSeason(sleeper);
+        OutboundStubs.telegramOk(telegram);
+        OutboundStubs.llmPhrases(llm, ANSWER);
+        OutboundStubs.telegramUpdates(telegram, OutboundStubs.textMessage("lineup"));
+    }
+
+    /** The Check that turns McCaffrey Out and sends Alert 1 with its buttons. */
+    private void alertOneIsOnTheLog() {
+        SleeperStubs.healthyInSeason(sleeper);
+        OutboundStubs.telegramOk(telegram);
+        OutboundStubs.llmPhrases(llm, "McCaffrey is Out. Bench him.");
+        checkRunner.runCheck();
+
+        clock.advance(Duration.ofSeconds(61));
+        sleeper.resetAll();
+        SleeperStubs.allNotModified(sleeper);
+        SleeperStubs.stubJson(sleeper, SleeperStubs.PLAYERS_PATH,
+                "sleeper/players-nfl-mccaffrey-out.json", "players-v2");
+        checkRunner.runCheck();
+
+        telegram.resetRequests();
+    }
+
+    @Test
+    void aQuestionSentToTheBotIsAnsweredInTheChat() {
+        telegramHoldsAnAsk();
+
+        assertThat(loop.poll()).isTrue();
+
+        telegram.verify(1, postRequestedFor(urlEqualTo(OutboundStubs.SEND_MESSAGE_PATH))
+                .withRequestBody(matchingJsonPath("$.chat_id",
+                        equalTo(String.valueOf(USER_CHAT_ID))))
+                .withRequestBody(containing(ANSWER)));
+    }
+
+    @Test
+    void theDriverAnswersOnAThreadOfItsOwn() throws InterruptedException {
+        telegramHoldsAnAsk();
+
+        loop.start();
+
+        // Nothing here polls: the driver's own thread does, as it does
+        // under the local profile once the context is up. A driver that
+        // failed to stop again would break the poll counts the rest of
+        // this class asserts.
+        for (int wait = 0; wait < 200 && sentMessages() == 0; wait++) {
+            Thread.sleep(50);
+        }
+        assertThat(sentMessages()).isEqualTo(1);
+    }
+
+    private int sentMessages() {
+        return telegram.findAll(postRequestedFor(urlEqualTo(OutboundStubs.SEND_MESSAGE_PATH)))
+                .size();
+    }
+
+    @Test
+    void aButtonTapReachesTheSameSeam() {
+        alertOneIsOnTheLog();
+        OutboundStubs.telegramCallbackAnswered(telegram);
+        OutboundStubs.telegramUpdates(telegram, OutboundStubs.callbackTap("done:1"));
+
+        assertThat(loop.poll()).isTrue();
+
+        telegram.verify(1, postRequestedFor(urlEqualTo(OutboundStubs.ANSWER_CALLBACK_PATH))
+                .withRequestBody(matchingJsonPath("$.callback_query_id", equalTo("cb-1"))));
+        assertThat(eventLog.all().stream()
+                .filter(event -> event.type() == EventType.USER_ACTION)
+                .map(Event::key))
+                .containsExactly("action:done:1");
+    }
+
+    @Test
+    void anUpdateTelegramHasAlreadyGivenUsIsNotAnsweredTwice() {
+        // The stub answers with the same update every time, as Telegram
+        // does until a later poll confirms it.
+        telegramHoldsAnAsk();
+
+        loop.poll();
+        loop.poll();
+
+        telegram.verify(1, postRequestedFor(urlEqualTo(OutboundStubs.SEND_MESSAGE_PATH)));
+        // The second poll confirmed the first update, which is what
+        // stops Telegram from offering it again.
+        telegram.verify(1, getRequestedFor(urlPathEqualTo(OutboundStubs.GET_UPDATES_PATH))
+                .withQueryParam("offset", equalTo("301")));
+    }
+
+    @Test
+    void aRestartDoesNotReplayAnAnsweredUpdate() {
+        telegramHoldsAnAsk();
+
+        assertThat(loop.poll()).isTrue();
+        // The process dies before the next poll confirms the update, so
+        // Telegram offers it again to the driver that comes up next.
+        assertThat(newLoop().poll()).isTrue();
+
+        telegram.verify(1, postRequestedFor(urlEqualTo(OutboundStubs.SEND_MESSAGE_PATH)));
+    }
+
+    @Test
+    void anUpdateFromAnotherChatIsDroppedAndStillConfirmed() {
+        SleeperStubs.healthyInSeason(sleeper);
+        OutboundStubs.telegramOk(telegram);
+        OutboundStubs.telegramCallbackAnswered(telegram);
+        OutboundStubs.llmPhrases(llm, ANSWER);
+        OutboundStubs.telegramUpdates(telegram,
+                OutboundStubs.callbackTap(9999, "done:1"),
+                OutboundStubs.textMessage(9999, "lineup"));
+
+        loop.poll();
+        loop.poll();
+
+        llm.verify(0, postRequestedFor(urlPathMatching(OutboundStubs.CHAT_COMPLETIONS_PATH)));
+        telegram.verify(0, postRequestedFor(urlEqualTo(OutboundStubs.SEND_MESSAGE_PATH)));
+        telegram.verify(0, postRequestedFor(urlEqualTo(OutboundStubs.ANSWER_CALLBACK_PATH)));
+        // A dropped update is confirmed like any other; otherwise
+        // Telegram would offer it on every poll for ever.
+        telegram.verify(1, getRequestedFor(urlPathEqualTo(OutboundStubs.GET_UPDATES_PATH))
+                .withQueryParam("offset", equalTo("301")));
+    }
+
+    @Test
+    void aTelegramOutageDoesNotWedgeTheDriver() {
+        telegram.stubFor(get(urlPathEqualTo(OutboundStubs.GET_UPDATES_PATH))
+                .willReturn(aResponse().withStatus(500)));
+
+        assertThat(loop.poll()).isFalse();
+
+        telegramHoldsAnAsk();
+        assertThat(loop.poll()).isTrue();
+        telegram.verify(1, postRequestedFor(urlEqualTo(OutboundStubs.SEND_MESSAGE_PATH))
+                .withRequestBody(containing(ANSWER)));
+    }
+
+    @Test
+    void theDriverIsLocalOnly() {
+        // This context runs the default profile, as the deployable does.
+        assertThat(context.getBeanNamesForType(LocalTelegramLoop.class)).isEmpty();
+    }
+}

--- a/src/test/java/otto/harness/OutboundStubs.java
+++ b/src/test/java/otto/harness/OutboundStubs.java
@@ -8,8 +8,10 @@ import com.github.tomakehurst.wiremock.stubbing.Scenario;
 import otto.storage.OttoJson;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching;
 
 /** Stubs for the outbound wires: Telegram and the LLM. */
@@ -17,6 +19,7 @@ public final class OutboundStubs {
 
     public static final String SEND_MESSAGE_PATH = "/bottest-bot-token/sendMessage";
     public static final String ANSWER_CALLBACK_PATH = "/bottest-bot-token/answerCallbackQuery";
+    public static final String GET_UPDATES_PATH = "/bottest-bot-token/getUpdates";
     public static final String CHAT_COMPLETIONS_PATH = "(/v1)?/chat/completions";
 
     /** The canned Lane A run: one tool call, then the narration. */
@@ -49,19 +52,40 @@ public final class OutboundStubs {
                 .withBody("{\"ok\":true,\"result\":true}")));
     }
 
-    /** One user tap on an inline button, as Telegram posts it to the webhook. */
+    /**
+     * The long-poll answer the local driver reads: the updates Telegram
+     * holds, in the order it hands them over.
+     */
+    public static void telegramUpdates(WireMockServer telegram, String... updates) {
+        telegram.stubFor(get(urlPathEqualTo(GET_UPDATES_PATH)).willReturn(aResponse()
+                .withStatus(200)
+                .withHeader("Content-Type", "application/json")
+                .withBody("{\"ok\":true,\"result\":[%s]}".formatted(String.join(",", updates)))));
+    }
+
+    /**
+     * One user tap on an inline button, as Telegram posts it to the
+     * webhook. Its update id is fixed, so two taps in one long-poll
+     * answer would read as the same update: give a scenario that needs
+     * two taps an update id of its own.
+     */
     public static String callbackTap(String callbackData) {
+        return callbackTap(WireSeamTest.USER_CHAT_ID, callbackData);
+    }
+
+    /** The same tap from any chat, to prove the chat gate works. */
+    public static String callbackTap(long chatId, String callbackData) {
         return """
                 {
                   "update_id": 200,
                   "callback_query": {
                     "id": "cb-1",
-                    "from": {"id": 4242, "is_bot": false, "first_name": "Brandon"},
-                    "message": {"message_id": 10},
+                    "from": {"id": %d, "is_bot": false, "first_name": "Brandon"},
+                    "message": {"message_id": 10, "chat": {"id": %d, "type": "private"}},
                     "data": %s
                   }
                 }
-                """.formatted(jsonString(callbackData));
+                """.formatted(chatId, chatId, jsonString(callbackData));
     }
 
     /** One free-text Ask from the user's chat, as Telegram posts it. */


### PR DESCRIPTION
Closes #28.

## Why

The Ask loop was built and tested in #13 and #14, but nobody could use it. `TelegramWebhook.handle()` was called only from tests.

The real front door is a Lambda function URL, and #19 owns it. #19 sits behind #17, #18 and now #29, so the Ask loop would have stayed unreachable for four more slices - and everything added to it in #14 through #18 would have shipped without a human ever asking it a question. Confirmed on 2026-08-08: a question sent to the bot got no answer, because nothing served the endpoint.

This gives the `local` profile a way in. It changes nothing about #19.

## The approach

Long polling, which is the first of the two options the issue offered.

A `@Profile("local")` bean calls Telegram `getUpdates` on a thread of its own and hands each update to `TelegramWebhook.handle()` - the same seam the deployed webhook will call. It sits beside `LocalCheckLoop` and `LocalNflverseJobs` as local-only code whose whole job is to let the operator run the real pipeline on their own machine.

The local HTTP endpoint was rejected. The app deliberately carries `spring-web` and not `spring-boot-starter-web`; adding the web starter would put Tomcat in the deployable that #19 wants thin under SnapStart, for a convenience only needed locally.

## Acceptance criteria

| Criterion | How it is met |
|---|---|
| A message reaches `handle()` and the reply lands in the chat | `dispatch` calls `webhook.handle(webhookSecret, update)`; the test asserts the `chat_id` and the reply text |
| A button tap reaches the same path | Taps take the same dispatch line; the test asserts `answerCallbackQuery` and the recorded action |
| Only the configured chat is read | `fromConfiguredChat` gates messages and taps; anything else is dropped and still confirmed |
| Nothing outside the `local` profile changes | `@Profile("local")`, no new bean, no new dependency; a test asserts no such bean in the default context |
| An update is not answered twice | Stored watermark, written before the update is answered; a restart does not replay |
| A wire test drives the driver, with no network | The whole test class extends `WireSeamTest`; every wire is WireMock |

## Verification

`JAVA_HOME=... mvn -o clean test` - **82 tests, 0 failures, 0 errors.** A `-Xlint:all` compile reports no warnings.

Also run against the real app on the `local` profile with a stub Telegram: the poll went out as `getUpdates?timeout=25`, the reply reached `sendMessage`, the offset advanced, the watermark was stored, and SIGTERM shut the app down in 0.5 s.

## Review findings fixed

Two bugs came out of review, both with regression cover:

- **`confirm()` sat outside the try block.** An `UncheckedIOException` from the store would have escaped `poll()` and killed the polling thread. The store write now comes first, a failure is caught, and the batch stops rather than confirming past an unstored update.
- **`stop()` could return while a poll was still in flight.** The bounded join was the only guard. A `volatile stopped` flag now gates dispatch, so a late-returning poll answers nothing.

## One manual step for the operator

Telegram gives a bot one delivery path. With a webhook registered, `getUpdates` answers 409.

The driver does not settle that for itself - it calls neither `setWebhook` nor `deleteWebhook`, because that registration is the deployed assistant's front door. A local run that quietly took delivery of the user's messages, or that exited leaving the webhook deleted, would be a worse failure than a poll that does not start.

So the operator clears the webhook by hand before a local run. The README carries the step, and the 409 is logged with that instruction. Once #19 is live, reading locally at the same time needs a second bot token.

Nothing is deployed today, so `deleteWebhook` is currently a no-op.

## Notes

This must not pre-empt #19. The Lambda function URL stays the real entry point, and `handle()` stays the seam both share.

ADR-0007 records the decisions: the polling choice, the confirm-before-answer ordering, the one-reader-at-a-time handoff, and the dedicated thread.