### PR TITLE
fix: gate button taps to the configured chat

### DIFF
--- a/docs/adr/0007-local-telegram-delivery.md
+++ b/docs/adr/0007-local-telegram-delivery.md
@@ -79,9 +79,12 @@ driver's copy went: two copies of one rule in two classes is the drift
 the gate exists to prevent. The driver now hands every update it takes
 to the seam and lets the seam decide.
 
-The gate reads `callback_query.message.chat` for a tap, with the sender
-as the fallback Telegram uses for a message too old to quote, and
-`message.chat` for free text. A dropped update is still confirmed -
+The gate reads `callback_query.message.chat` for a tap and
+`message.chat` for free text, and it passes nothing else.
+`callback_query.from` names the user who tapped, not the chat the tap
+came from, so it cannot stand in: it would authorize a chat by a user
+id. Telegram leaves the message out of a tap on one too old to quote,
+and such a tap is dropped. A dropped update is still confirmed -
 otherwise the poll would hand it back for ever - and a dropped tap is
 still answered, because Telegram offers a `callback_query` again until
 an `answerCallbackQuery` confirms it.

--- a/docs/adr/0007-local-telegram-delivery.md
+++ b/docs/adr/0007-local-telegram-delivery.md
@@ -84,7 +84,22 @@ The gate reads `callback_query.message.chat` for a tap and
 `callback_query.from` names the user who tapped, not the chat the tap
 came from, so it cannot stand in: it would authorize a chat by a user
 id. Telegram leaves the message out of a tap on one too old to quote,
-and such a tap is dropped. A dropped update is still confirmed -
-otherwise the poll would hand it back for ever - and a dropped tap is
-still answered, because Telegram offers a `callback_query` again until
-an `answerCallbackQuery` confirms it.
+about two days, and such a tap is dropped too. A dropped update is
+still confirmed - otherwise the poll would hand it back for ever - and
+a dropped tap is still answered, because Telegram offers a
+`callback_query` again until an `answerCallbackQuery` confirms it.
+
+## Two refusals, because the user sees the answer
+
+The answer to a refused tap is the only part of this the user reads, so
+it has to be true of his case. The two refusals are not the same case.
+A tap that names another chat is a stranger's, and "I do not answer
+this chat" is what it deserves. A tap that names no chat is almost
+always the user's own, on an Alert he left for a day or two, and
+telling him he is in the wrong chat would be false as well as
+confusing: it is his chat, and the Alert is the thing that is out of
+date. That tap is answered with "That alert is too old to act on. Ask
+me instead", which is true and gives him the way forward.
+
+Both refusals act on no Alert, and both are answered. Only the wording
+tells them apart.

--- a/docs/adr/0007-local-telegram-delivery.md
+++ b/docs/adr/0007-local-telegram-delivery.md
@@ -65,14 +65,23 @@ put the same question to the model again and text the user twice. A
 failure while answering is caught for the same reason: one bad update
 is dropped rather than offered again on every poll for ever.
 
-## The driver gates the chat, not only the seam
+## The seam gates the chat, and the driver does not repeat it
 
 ADR-0002 recorded that only the configured chat reaches the Ask loop. A
-button tap does not pass that gate: it carries a callback id and an
-alert id, and the seam acts on the alert. Nothing reaches the Ask loop,
+button tap did not pass that gate: it carries a callback id and an
+alert id, and the seam acts on the alert. Nothing reached the Ask loop,
 but a stray tap could still record a user action.
 
-So the driver applies the gate to every update it takes, taps included,
-and reads `callback_query.message.chat` with the sender as the fallback
-Telegram uses for old messages. A dropped update is still confirmed -
-otherwise the poll would hand it back for ever.
+The driver first carried a gate of its own to cover that, because the
+seam gated only free text. Issue #29 moved the gate into
+`TelegramWebhook.handle`, where one check covers every branch, so the
+driver's copy went: two copies of one rule in two classes is the drift
+the gate exists to prevent. The driver now hands every update it takes
+to the seam and lets the seam decide.
+
+The gate reads `callback_query.message.chat` for a tap, with the sender
+as the fallback Telegram uses for a message too old to quote, and
+`message.chat` for free text. A dropped update is still confirmed -
+otherwise the poll would hand it back for ever - and a dropped tap is
+still answered, because Telegram offers a `callback_query` again until
+an `answerCallbackQuery` confirms it.

--- a/src/main/java/otto/telegram/LocalTelegramLoop.java
+++ b/src/main/java/otto/telegram/LocalTelegramLoop.java
@@ -189,10 +189,6 @@ public class LocalTelegramLoop {
         if (!confirm(updateId)) {
             return false;
         }
-        if (!fromConfiguredChat(update)) {
-            log.info("Dropped update {}: it is not from the chat the assistant serves", updateId);
-            return true;
-        }
         try {
             if (webhook.handle(webhookSecret, update.toString()) != WebhookResult.OK) {
                 log.warn("Update {} was refused: the configured webhook secret is not"
@@ -225,20 +221,6 @@ public class LocalTelegramLoop {
         }
         lastUpdateId = updateId;
         return true;
-    }
-
-    /**
-     * Only the one chat the assistant serves is read. The seam already
-     * drops free text from anywhere else, but a button tap reaches the
-     * Alert actions without passing that gate, so the driver gates both.
-     */
-    private boolean fromConfiguredChat(JsonNode update) {
-        JsonNode tap = update.path("callback_query");
-        if (tap.isMissingNode()) {
-            return chatId.equals(update.path("message").path("chat").path("id").asText(""));
-        }
-        String chat = tap.path("message").path("chat").path("id").asText("");
-        return chatId.equals(chat.isEmpty() ? tap.path("from").path("id").asText("") : chat);
     }
 
     private Optional<JsonNode> fetchUpdates() {

--- a/src/main/java/otto/telegram/TelegramWebhook.java
+++ b/src/main/java/otto/telegram/TelegramWebhook.java
@@ -88,19 +88,18 @@ public class TelegramWebhook {
     /**
      * Telegram carries the chat on the message the update belongs to -
      * the message itself for free text, the message the button hangs on
-     * for a tap. It leaves that message out of a tap on one too old to
-     * quote, and the sender is all it gives then.
+     * for a tap. An update that names no chat cannot pass: the sender it
+     * does name is a user, and a user is not the chat the assistant
+     * serves. Telegram leaves the message out of a tap on one too old to
+     * quote, so the cost of that is a refused tap on a stale Alert.
      */
     private boolean fromConfiguredChat(JsonNode update) {
         if (chatId == null || chatId.isBlank()) {
             return false;
         }
         JsonNode tap = update.path("callback_query");
-        if (tap.isMissingNode()) {
-            return chatId.equals(update.path("message").path("chat").path("id").asText(""));
-        }
-        String chat = tap.path("message").path("chat").path("id").asText("");
-        return chatId.equals(chat.isEmpty() ? tap.path("from").path("id").asText("") : chat);
+        JsonNode message = tap.isMissingNode() ? update.path("message") : tap.path("message");
+        return chatId.equals(message.path("chat").path("id").asText(""));
     }
 
     /** Free text goes to the Ask loop and its reply back to the chat. */

--- a/src/main/java/otto/telegram/TelegramWebhook.java
+++ b/src/main/java/otto/telegram/TelegramWebhook.java
@@ -77,10 +77,11 @@ public class TelegramWebhook {
             return;
         }
         if (!fromConfiguredChat(update)) {
-            log.warn("Update dropped: it is not from the chat the assistant serves");
             if (isTap) {
-                acknowledge(callback, "I do not answer this chat.");
+                acknowledge(callback, refusalFor(callback));
+                return;
             }
+            log.warn("Update dropped: it is not from the chat the assistant serves");
             return;
         }
         if (isTap) {
@@ -88,6 +89,23 @@ public class TelegramWebhook {
             return;
         }
         answerAsk(update.path("message"));
+    }
+
+    /**
+     * A refused tap is answered, so the wording has to be true. Only one
+     * of the two refusals is about who tapped. Telegram stops quoting
+     * the message a button hangs on once it is about two days old, and
+     * the tap then names no chat, so the user's own tap on an Alert he
+     * left for a day or two lands here. Telling him he is a stranger
+     * would be false; the Alert is the thing that is out of date.
+     */
+    private String refusalFor(JsonNode callback) {
+        if (callback.path("message").path("chat").path("id").asText("").isEmpty()) {
+            log.warn("Tap dropped: it names no chat, so the alert it acts on is too old");
+            return "That alert is too old to act on. Ask me instead.";
+        }
+        log.warn("Tap dropped: it is not from the chat the assistant serves");
+        return "I do not answer this chat.";
     }
 
     /**

--- a/src/main/java/otto/telegram/TelegramWebhook.java
+++ b/src/main/java/otto/telegram/TelegramWebhook.java
@@ -27,8 +27,9 @@ import otto.storage.OttoJson;
  * <p>The token guards the endpoint and the chat gate guards the
  * identity, so both are needed: anybody who holds the token reaches
  * this seam, and only the one chat the assistant serves is answered.
- * The gate is applied once, to the whole update, so no branch of
- * {@link #handle} can be added without it.
+ * The gate is applied once, to the whole update, before the update is
+ * read for what it asks. Every kind of update goes through that one
+ * check, so a new kind cannot be added without it.
  */
 @Component
 public class TelegramWebhook {
@@ -71,6 +72,10 @@ public class TelegramWebhook {
     private void dispatch(JsonNode update) {
         JsonNode callback = update.path("callback_query");
         boolean isTap = !callback.isMissingNode();
+        if (isTap && callback.path("id").asText("").isEmpty()) {
+            log.warn("Tap dropped: it carries no callback id, so it cannot be answered");
+            return;
+        }
         if (!fromConfiguredChat(update)) {
             log.warn("Update dropped: it is not from the chat the assistant serves");
             if (isTap) {
@@ -121,17 +126,14 @@ public class TelegramWebhook {
     }
 
     /**
-     * Every tap that reaches the seam is answered, the ones this chat
-     * does not own included: Telegram offers a callback_query again
-     * until an answerCallbackQuery confirms it, so a silent drop buys a
-     * repeat rather than quiet.
+     * Every tap the seam acts on is answered, the ones from another chat
+     * included. Telegram offers a callback_query again until an
+     * answerCallbackQuery confirms it, so a silent drop causes repeats.
+     * A tap that carries no id is refused before this point, because
+     * such a tap can never be answered.
      */
     private void acknowledge(JsonNode callback, String text) {
-        String callbackId = callback.path("id").asText("");
-        if (callbackId.isEmpty()) {
-            return;
-        }
-        telegram.answerCallbackQuery(callbackId, text);
+        telegram.answerCallbackQuery(callback.path("id").asText(""), text);
     }
 
     /** A body Telegram would never send is logged and dropped, never retried. */

--- a/src/main/java/otto/telegram/TelegramWebhook.java
+++ b/src/main/java/otto/telegram/TelegramWebhook.java
@@ -23,6 +23,12 @@ import otto.storage.OttoJson;
  * carry the right token is rejected before any parsing. Invoked
  * directly by wire-seam tests; the deployed HTTP wrapper delegates to
  * it and maps the result to a status code.
+ *
+ * <p>The token guards the endpoint and the chat gate guards the
+ * identity, so both are needed: anybody who holds the token reaches
+ * this seam, and only the one chat the assistant serves is answered.
+ * The gate is applied once, to the whole update, so no branch of
+ * {@link #handle} can be added without it.
  */
 @Component
 public class TelegramWebhook {
@@ -51,41 +57,82 @@ public class TelegramWebhook {
             log.warn("Webhook call rejected: bad or missing secret token");
             return WebhookResult.FORBIDDEN;
         }
-        parse(updateJson).ifPresent(update -> {
-            JsonNode callback = update.path("callback_query");
-            if (!callback.isMissingNode()) {
-                answerTap(callback);
-                return;
-            }
-            answerAsk(update.path("message"));
-        });
+        parse(updateJson).ifPresent(this::dispatch);
         return WebhookResult.OK;
     }
 
     /**
-     * Free text goes to the Ask loop and its reply back to the chat.
-     * Only the one chat the assistant serves is answered; anything else
-     * that reaches this endpoint is dropped without a model call.
+     * The one chat gate, applied to every update before it is read for
+     * what it asks. The secret token guards the endpoint; this guards
+     * the identity, so anybody who holds the token still acts on no
+     * Alert and asks no question of the assistant. Gating here rather
+     * than in each branch is what keeps a later branch from missing it.
      */
+    private void dispatch(JsonNode update) {
+        JsonNode callback = update.path("callback_query");
+        boolean isTap = !callback.isMissingNode();
+        if (!fromConfiguredChat(update)) {
+            log.warn("Update dropped: it is not from the chat the assistant serves");
+            if (isTap) {
+                acknowledge(callback, "I do not answer this chat.");
+            }
+            return;
+        }
+        if (isTap) {
+            answerTap(callback);
+            return;
+        }
+        answerAsk(update.path("message"));
+    }
+
+    /**
+     * Telegram carries the chat on the message the update belongs to -
+     * the message itself for free text, the message the button hangs on
+     * for a tap. It leaves that message out of a tap on one too old to
+     * quote, and the sender is all it gives then.
+     */
+    private boolean fromConfiguredChat(JsonNode update) {
+        if (chatId == null || chatId.isBlank()) {
+            return false;
+        }
+        JsonNode tap = update.path("callback_query");
+        if (tap.isMissingNode()) {
+            return chatId.equals(update.path("message").path("chat").path("id").asText(""));
+        }
+        String chat = tap.path("message").path("chat").path("id").asText("");
+        return chatId.equals(chat.isEmpty() ? tap.path("from").path("id").asText("") : chat);
+    }
+
+    /** Free text goes to the Ask loop and its reply back to the chat. */
     private void answerAsk(JsonNode message) {
         String text = message.path("text").asText("");
-        if (text.isBlank() || !chatId.equals(message.path("chat").path("id").asText(""))) {
+        if (text.isBlank()) {
             return;
         }
         telegram.sendMessage(ask.answer(text));
     }
 
     private void answerTap(JsonNode callback) {
-        String callbackId = callback.path("id").asText("");
-        if (callbackId.isEmpty()) {
-            return;
-        }
         Matcher tap = TAP.matcher(callback.path("data").asText(""));
         String ack = tap.matches()
                 ? alertActions.apply(tap.group(1), Long.parseLong(tap.group(2)))
                         .orElse("That alert is no longer on my log.")
                 : "I do not recognize that button.";
-        telegram.answerCallbackQuery(callbackId, ack);
+        acknowledge(callback, ack);
+    }
+
+    /**
+     * Every tap that reaches the seam is answered, the ones this chat
+     * does not own included: Telegram offers a callback_query again
+     * until an answerCallbackQuery confirms it, so a silent drop buys a
+     * repeat rather than quiet.
+     */
+    private void acknowledge(JsonNode callback, String text) {
+        String callbackId = callback.path("id").asText("");
+        if (callbackId.isEmpty()) {
+            return;
+        }
+        telegram.answerCallbackQuery(callbackId, text);
     }
 
     /** A body Telegram would never send is logged and dropped, never retried. */

--- a/src/test/java/otto/LocalPollingScenarioTest.java
+++ b/src/test/java/otto/LocalPollingScenarioTest.java
@@ -194,7 +194,11 @@ class LocalPollingScenarioTest extends WireSeamTest {
 
         llm.verify(0, postRequestedFor(urlPathMatching(OutboundStubs.CHAT_COMPLETIONS_PATH)));
         telegram.verify(0, postRequestedFor(urlEqualTo(OutboundStubs.SEND_MESSAGE_PATH)));
-        telegram.verify(0, postRequestedFor(urlEqualTo(OutboundStubs.ANSWER_CALLBACK_PATH)));
+        assertThat(eventLog.all().stream()
+                .filter(event -> event.type() == EventType.USER_ACTION)).isEmpty();
+        // The tap acts on no Alert, but it is still acknowledged, which
+        // is what stops Telegram offering the same tap again.
+        telegram.verify(1, postRequestedFor(urlEqualTo(OutboundStubs.ANSWER_CALLBACK_PATH)));
         // A dropped update is confirmed like any other; otherwise
         // Telegram would offer it on every poll for ever.
         telegram.verify(1, getRequestedFor(urlPathEqualTo(OutboundStubs.GET_UPDATES_PATH))

--- a/src/test/java/otto/WebhookScenarioTest.java
+++ b/src/test/java/otto/WebhookScenarioTest.java
@@ -101,6 +101,34 @@ class WebhookScenarioTest extends WireSeamTest {
                 .containsExactly("action:done:1");
     }
 
+    /**
+     * Telegram leaves the message out of a tap on one too old to quote,
+     * and the sender it still names is a user, not a chat. A tap that
+     * names no chat therefore acts on nothing, whoever sent it.
+     */
+    @Test
+    void aButtonTapThatNamesNoChatActsOnNothingAndIsStillAcknowledged() {
+        runHealthyBaselineCheck();
+        runDeclineCheck();
+        OutboundStubs.telegramCallbackAnswered(telegram);
+
+        WebhookResult result = webhook.handle(WEBHOOK_SECRET, """
+                {
+                  "update_id": 200,
+                  "callback_query": {
+                    "id": "cb-1",
+                    "from": {"id": %d, "is_bot": false, "first_name": "Brandon"},
+                    "data": "done:1"
+                  }
+                }
+                """.formatted(USER_CHAT_ID));
+
+        assertThat(result).isEqualTo(WebhookResult.OK);
+        telegram.verify(1, postRequestedFor(urlEqualTo(OutboundStubs.ANSWER_CALLBACK_PATH)));
+        assertThat(eventLog.all().stream()
+                .filter(event -> event.type() == EventType.USER_ACTION)).isEmpty();
+    }
+
     /** An Alert with buttons for the tap tests to act on. */
     private void runHealthyBaselineCheck() {
         SleeperStubs.healthyInSeason(sleeper);

--- a/src/test/java/otto/WebhookScenarioTest.java
+++ b/src/test/java/otto/WebhookScenarioTest.java
@@ -1,15 +1,23 @@
 package otto;
 
+import java.time.Duration;
+
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import otto.check.CheckRunner;
 import otto.events.EventLog;
+import otto.events.EventType;
+import otto.harness.OutboundStubs;
+import otto.harness.SleeperStubs;
 import otto.harness.WireSeamTest;
 import otto.telegram.TelegramWebhook;
 import otto.telegram.WebhookResult;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.anyRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
@@ -23,6 +31,12 @@ class WebhookScenarioTest extends WireSeamTest {
     private static final String BENIGN_UPDATE = """
             {"update_id": 100, "message": {"message_id": 7, "text": "hello"}}
             """;
+
+    /** Any chat that is not the one the assistant serves. */
+    private static final long FOREIGN_CHAT_ID = 9999;
+
+    @Autowired
+    private CheckRunner checkRunner;
 
     @Autowired
     private TelegramWebhook webhook;
@@ -43,5 +57,64 @@ class WebhookScenarioTest extends WireSeamTest {
     @Test
     void aRequestWithTheRightSecretTokenIsAccepted() {
         assertThat(webhook.handle(WEBHOOK_SECRET, BENIGN_UPDATE)).isEqualTo(WebhookResult.OK);
+    }
+
+    /**
+     * The secret token guards the endpoint; the chat gate guards the
+     * identity. Anybody who holds the secret can reach this seam, so a
+     * button tap from another chat must act on no Alert of the user's.
+     * It is still acknowledged: Telegram offers a callback_query again
+     * until it gets an answerCallbackQuery.
+     */
+    @Test
+    void aButtonTapFromAnotherChatActsOnNothingAndIsStillAcknowledged() {
+        runHealthyBaselineCheck();
+        runDeclineCheck();
+        OutboundStubs.telegramCallbackAnswered(telegram);
+
+        WebhookResult result = webhook.handle(WEBHOOK_SECRET,
+                OutboundStubs.callbackTap(FOREIGN_CHAT_ID, "done:1"));
+
+        assertThat(result).isEqualTo(WebhookResult.OK);
+        telegram.verify(1, postRequestedFor(urlEqualTo(OutboundStubs.ANSWER_CALLBACK_PATH)));
+        assertThat(eventLog.all().stream()
+                .filter(event -> event.type() == EventType.USER_ACTION)).isEmpty();
+    }
+
+    /**
+     * The same tap from the chat the assistant serves does the work, so
+     * the gate reads the chat and not some other part of the update.
+     */
+    @Test
+    void aButtonTapFromTheConfiguredChatStillActsOnTheAlert() {
+        runHealthyBaselineCheck();
+        runDeclineCheck();
+        OutboundStubs.telegramCallbackAnswered(telegram);
+
+        WebhookResult result = webhook.handle(WEBHOOK_SECRET, OutboundStubs.callbackTap("done:1"));
+
+        assertThat(result).isEqualTo(WebhookResult.OK);
+        telegram.verify(1, postRequestedFor(urlEqualTo(OutboundStubs.ANSWER_CALLBACK_PATH)));
+        assertThat(eventLog.all().stream()
+                .filter(event -> event.type() == EventType.USER_ACTION)
+                .map(event -> event.key()))
+                .containsExactly("action:done:1");
+    }
+
+    /** An Alert with buttons for the tap tests to act on. */
+    private void runHealthyBaselineCheck() {
+        SleeperStubs.healthyInSeason(sleeper);
+        OutboundStubs.telegramOk(telegram);
+        OutboundStubs.llmPhrases(llm, "McCaffrey is Out. Bench him.");
+        checkRunner.runCheck();
+    }
+
+    private void runDeclineCheck() {
+        clock.advance(Duration.ofSeconds(61));
+        sleeper.resetAll();
+        SleeperStubs.allNotModified(sleeper);
+        SleeperStubs.stubJson(sleeper, SleeperStubs.PLAYERS_PATH,
+                "sleeper/players-nfl-mccaffrey-out.json", "players-v2");
+        checkRunner.runCheck();
     }
 }

--- a/src/test/java/otto/WebhookScenarioTest.java
+++ b/src/test/java/otto/WebhookScenarioTest.java
@@ -16,6 +16,8 @@ import otto.telegram.WebhookResult;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.anyRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.matchingJsonPath;
 import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -76,7 +78,9 @@ class WebhookScenarioTest extends WireSeamTest {
                 OutboundStubs.callbackTap(FOREIGN_CHAT_ID, "done:1"));
 
         assertThat(result).isEqualTo(WebhookResult.OK);
-        telegram.verify(1, postRequestedFor(urlEqualTo(OutboundStubs.ANSWER_CALLBACK_PATH)));
+        telegram.verify(1, postRequestedFor(urlEqualTo(OutboundStubs.ANSWER_CALLBACK_PATH))
+                .withRequestBody(matchingJsonPath(
+                        "$.text", equalTo("I do not answer this chat."))));
         assertThat(eventLog.all().stream()
                 .filter(event -> event.type() == EventType.USER_ACTION)).isEmpty();
     }
@@ -104,10 +108,13 @@ class WebhookScenarioTest extends WireSeamTest {
     /**
      * Telegram leaves the message out of a tap on one too old to quote,
      * and the sender it still names is a user, not a chat. A tap that
-     * names no chat therefore acts on nothing, whoever sent it.
+     * names no chat therefore acts on nothing, whoever sent it. This is
+     * the user's own tap on an old Alert far more often than it is a
+     * stranger's, so the answer says the Alert is old and does not tell
+     * the user he is in the wrong chat.
      */
     @Test
-    void aButtonTapThatNamesNoChatActsOnNothingAndIsStillAcknowledged() {
+    void aButtonTapThatNamesNoChatIsRefusedAsAStaleAlert() {
         runHealthyBaselineCheck();
         runDeclineCheck();
         OutboundStubs.telegramCallbackAnswered(telegram);
@@ -124,7 +131,9 @@ class WebhookScenarioTest extends WireSeamTest {
                 """.formatted(USER_CHAT_ID));
 
         assertThat(result).isEqualTo(WebhookResult.OK);
-        telegram.verify(1, postRequestedFor(urlEqualTo(OutboundStubs.ANSWER_CALLBACK_PATH)));
+        telegram.verify(1, postRequestedFor(urlEqualTo(OutboundStubs.ANSWER_CALLBACK_PATH))
+                .withRequestBody(matchingJsonPath("$.text",
+                        equalTo("That alert is too old to act on. Ask me instead."))));
         assertThat(eventLog.all().stream()
                 .filter(event -> event.type() == EventType.USER_ACTION)).isEmpty();
     }


### PR DESCRIPTION
Closes #29

## Why

`TelegramWebhook.handle()` guarded its two branches differently. Free text was gated by chat. A button tap was gated only by the shared secret, and the chat that sent the tap was never inspected.

Today nothing serves the endpoint, so this is harmless. #19 puts the handler behind a Lambda function URL. From then on, a tap from any chat holding the secret could resolve, Ignore or Mute a Recommendation belonging to the user.

Found during the review of #28, and out of scope there.

## What changed

**One gate, applied once.** `handle()` now passes every update to `dispatch()`, which applies the chat gate before it branches. The gate reads `callback_query.message.chat.id` for a tap and `message.chat.id` for free text. The duplicate check inside `answerAsk` is gone, so the two branches cannot drift again.

**A refused tap is still answered.** Telegram retries a `callback_query` that gets no `answerCallbackQuery`, so a silent drop causes repeats. A refused tap does no `AlertActions` work and is still acknowledged.

**Two refusals, because the user reads the answer.** Telegram leaves `message` off any tap on a message older than about 48 hours, so such a tap names no chat at all. Telling the user "I do not answer this chat" is untrue - it is his chat. The two cases now read differently:

| Case | Answer |
|---|---|
| Tap names another chat | `I do not answer this chat.` |
| Tap names no chat | `That alert is too old to act on. Ask me instead.` |

**A second copy of the gate is removed.** `LocalTelegramLoop` carried its own chat check, added by #28 because the seam did not gate taps. Two copies of one rule in two classes is the drift this PR exists to stop. The driver now hands every update to the seam.

The secret token check is unchanged. It guards the endpoint; the chat gate guards the identity.

## Reproduction

The bug was reproduced end to end before it was fixed. `WebhookScenarioTest.aButtonTapFromAnotherChatActsOnNothingAndIsStillAcknowledged` sends a real `callback_query` from chat 9999 with a valid secret token, after a Check that put an Alert with buttons on the Event Log.

Before the fix:

```
java.lang.AssertionError:
Expecting empty but was: [Event[key=action:done:1, type=USER_ACTION, ...
 facts={player=Christian McCaffrey, healthAtTap=OUT, action=done, playerId=4034, ...}]]
```

A foreign chat resolved the user's Recommendation. The test passes after the fix.

## Tests

`Tests run: 139, Failures: 0, Errors: 0, Skipped: 0` - BUILD SUCCESS.

Both wordings are pinned on the wire, not counted:

```java
telegram.verify(1, postRequestedFor(urlEqualTo(OutboundStubs.ANSWER_CALLBACK_PATH))
        .withRequestBody(matchingJsonPath("$.text",
                equalTo("That alert is too old to act on. Ask me instead."))));
```

New coverage: a tap from a foreign chat, a tap from the configured chat, a tap naming no chat, a tap with no callback id, and `LocalPollingScenarioTest` now asserts no `USER_ACTION` and one acknowledgement.

## Known limitation

Telegram strips the chat from any tap on an old message, a stranger's included. So a stranger tapping a two-day-old button also reads "That alert is too old to act on. Ask me instead.", and the advice to Ask does not work for him, because the same gate drops his free text. The payload gives no way to tell the two apart. There is no security cost - that path does no Alert work either way. ADR-0007 concedes the point rather than hiding it.

## Docs

`docs/adr/0007-local-telegram-delivery.md` gains "Two refusals, because the user sees the answer", and records the removal of the driver's duplicate gate.
