### PR TITLE
feat: deploy the assistant on AWS (CDK, Lambda SnapStart)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,11 @@
 .env
 CONTEXT.md
 docs/agents/
+docs/local/
 AGENTS.md
 CLAUDE.md
 .idea/
 target/
 data/
+cdk.out/
+.impeccable/

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ mvn package
 cd infra && npx aws-cdk@2 deploy -c alertEmail=you@example.com
 ```
 
-The same app, invoked two ways: a scheduled Lambda runs the Check every minute, and a Lambda function URL takes Telegram's updates. Both use SnapStart, so a restore answers without waiting for Spring to start. Documents go to one S3 object and one DynamoDB table, secrets to Parameter Store. If the Check loop stops, an alarm texts you.
+The same app, invoked two ways: a scheduled Lambda runs the Check every minute, and a Lambda function URL takes Telegram's updates. Documents go to one S3 object and one DynamoDB table, secrets to Parameter Store. If the Check loop stops, an alarm texts you.
 
 ## Under the hood
 

--- a/README.md
+++ b/README.md
@@ -80,14 +80,26 @@ It also answers: your roster and how each player is doing, two players compared,
 
 Replies run a couple of lines. Reply "why" or "more" for the reasoning behind one.
 
+## Run it in the cloud
+
+One CDK stack deploys the whole assistant, so you can rebuild it from this repo. See [docs/deploy.md](docs/deploy.md).
+
+```sh
+mvn package
+cd infra && npx aws-cdk@2 deploy -c alertEmail=you@example.com
+```
+
+The same app, invoked two ways: a scheduled Lambda runs the Check every minute, and a Lambda function URL takes Telegram's updates. Both use SnapStart, so a restore answers without waiting for Spring to start. Documents go to one S3 object and one DynamoDB table, secrets to Parameter Store. If the Check loop stops, an alarm texts you.
+
 ## Under the hood
 
-Java 25, Spring Boot, Spring AI, Maven. No database yet: JSON files under `./data` stand in for what AWS supplies later.
+Java 25, Spring Boot, Spring AI, Maven. Storage is one seam with two backends: JSON files under `./data` on your machine, S3 plus DynamoDB when deployed.
 
 Otto runs one Check a minute. It polls Sleeper, builds a snapshot, diffs it against the last one, finds the problems, and works out what to do about them. Only the result reaches the model, and only to be turned into English.
 
 ```sh
-mvn test
+mvn test              # the app
+mvn -f infra/pom.xml test   # the stack, read back off the template it synthesizes
 ```
 
 No test touches the network or spends a token. Stub servers play Sleeper, Telegram and the model from recorded fixtures.
@@ -95,4 +107,4 @@ No test touches the network or spends a token. Stub servers play Sleeper, Telegr
 ## Not built yet
 
 - Trade evaluation ([#18](https://github.com/brandon-sanchez/Otto/issues/18))
-- Running anywhere but your own machine ([#19](https://github.com/brandon-sanchez/Otto/issues/19))
+- A live season ([#20](https://github.com/brandon-sanchez/Otto/issues/20))

--- a/docs/adr/0008-aws-deployment.md
+++ b/docs/adr/0008-aws-deployment.md
@@ -20,8 +20,22 @@ webhook function that Telegram posts to. One artifact means one build,
 one set of dependencies, and one place a behavior can live.
 
 Both run on arm64, Java 25, 1024 MB, with SnapStart on published
-versions. The Spring context is built while `OttoRuntime` loads, which
-is Lambda's init phase, so the snapshot holds a started app.
+versions.
+
+The Spring context is built from each handler's **constructor**, and
+the reason is worth stating because the obvious alternative is wrong.
+Building it in a static initializer on `OttoRuntime` looks equivalent
+and is not: Java initializes a class on first active use, and nothing
+uses that class until a handler asks it for a bean, which is the first
+invocation. The snapshot would then hold an application that had never
+started, and every execution environment would pay a full Spring start
+while the user waited. Lambda constructs the handler during init, so
+the constructor is the hook that actually runs before the snapshot is
+taken.
+
+The alarm forwarder deliberately does not do this. It has no SnapStart,
+and an init phase without SnapStart is limited to 10 seconds, which is
+less than Spring takes.
 
 SnapStart restores a *version*, never `$LATEST`. Both functions
 therefore sit behind an alias, and the schedules and the function URL

--- a/docs/adr/0008-aws-deployment.md
+++ b/docs/adr/0008-aws-deployment.md
@@ -94,10 +94,23 @@ only realistic case - this run's value was derived from a version that
 no longer exists, and writing it would drop the user's tap. There is no
 general way to merge two documents at this level, so the backend
 compares each document against what it held when the run first touched
-it and refuses loudly when that has moved. The Check then errors, the
-error alarm sees it, and the next minute's run reads the Event Log with
-the tap already in it. Losing one Check is cheap; losing a Done tap
-means re-alerting a problem the user has already dealt with.
+it and refuses loudly when that has moved.
+
+The two entry points answer that refusal differently, because what
+they lose is not the same. The Check errors: the error alarm sees it,
+and the next minute's run reads the Event Log with the tap already in
+it. Losing one Check costs a minute of latency on news that is at most
+a minute old anyway.
+
+The webhook cannot shrug in the same way. The tap is the user's, he
+has already been told it worked - the acknowledgement goes out while
+the update is handled, before the run stores anything - and no later
+run will retry it for him. So a refused webhook write answers Telegram
+with a failure, and Telegram sends the update again. That is safe
+because the Event Log keys on the event id: the same tap applied twice
+appends once. Any other failure still answers 200 and is let go, since
+a body this build cannot handle would fail the same way on every
+retry.
 
 The batching costs one guarantee the file storage gave. An Alert is
 sent to Telegram during the run, and the Event Log entry that dedups it

--- a/docs/adr/0008-aws-deployment.md
+++ b/docs/adr/0008-aws-deployment.md
@@ -1,0 +1,208 @@
+# ADR-0008: The assistant runs itself on AWS
+
+Status: accepted (2026-08-09, issue #19)
+
+Every slice before this one ran on the operator's laptop. The Check
+loop was a `@Scheduled` method, the Telegram front door was a long
+poll, and storage was a directory of JSON files. This ADR records what
+carries each of the three in the cloud, and what the stack deliberately
+does not contain.
+
+AWS lands last and stays thin, as the spec's build order says. Nothing
+here changes what the assistant decides; it changes only where the
+deciding happens.
+
+## Two entry points, one deployable
+
+The whole app deploys as one zip and is invoked through two handlers: a
+scheduled function that runs the Check and the two nflverse jobs, and a
+webhook function that Telegram posts to. One artifact means one build,
+one set of dependencies, and one place a behavior can live.
+
+Both run on arm64, Java 25, 1024 MB, with SnapStart on published
+versions. The Spring context is built while `OttoRuntime` loads, which
+is Lambda's init phase, so the snapshot holds a started app.
+
+SnapStart restores a *version*, never `$LATEST`. Both functions
+therefore sit behind an alias, and the schedules and the function URL
+target the alias. A schedule pointed at the bare function would run a
+cold Spring start every minute.
+
+The webhook is a Lambda function URL. Telegram needs one public POST
+endpoint and nothing else - no routes, no authorizers, no usage plans -
+so API Gateway would add a hop, a bill, and a second thing to
+configure. The URL's auth type is NONE because Telegram signs nothing
+AWS can check; the guard is the secret token Telegram echoes, which
+`TelegramWebhook` already checks in constant time.
+
+## Three schedules, and no schedule for anything derived
+
+EventBridge Scheduler holds exactly what the spec names: the 1-minute
+Check, the hourly nflverse timestamp check, and the nightly
+defense-versus-position build. Each names its job in the payload, and
+`ScheduledJob` refuses a name this build does not have rather than
+falling back to a Check - a schedule naming a job that is gone is a
+deployment mistake, and running the wrong job would hide it.
+
+The Lock Ladder, the Tuesday waiver Alert and the 20-minute Done
+follow-up get no schedule. They ride the 1-minute loop and the Event
+Log, which is what keeps their timing and the Check's from drifting
+apart.
+
+The scheduled function is limited to one run at a time. Two overlapping
+runs would read the same stored documents and each write what the other
+had not seen. The Check does not retry - the next tick is one minute
+away and is the retry. The nflverse jobs do retry, because their next
+tick is an hour or a day away.
+
+## Storage splits by how a document grows
+
+The spec asks for one S3 bucket for big documents and one DynamoDB
+table for small records, with a minute of writes batched into one
+object. `DocumentPlacement` is the rule: small means a document whose size is
+settled by its shape and stays well inside DynamoDB's 400 KB item limit
+however long the season runs - Settings, the Watchlist, Mutes, the
+conversation and three markers. Big means everything else: the
+Snapshots, the Player Directory, the nflverse feeds,
+defense-versus-position and the Event Log.
+
+Small is the named list and big is the default, because of what each
+mistake costs. A document that should have been small and goes to S3
+costs a slot in the bundle. A document that should have been big and
+goes to DynamoDB works until the season pushes it past 400 KB, which
+happens in the middle of a season rather than at a deploy. So the
+document nobody has thought about lands in the store that cannot be
+outgrown.
+
+The big documents live in one object. A Check touches the Snapshot, the
+Event Log and the feeds, and batching them costs one round trip a
+minute rather than one per document. The run reads the object once and
+writes it once, at the end, whether or not the run finished - a Check
+that half succeeded still keeps what it learned.
+
+Two entry points write that object: the Check and the webhook both
+append to the Event Log. The write therefore carries the ETag the run
+read, S3 refuses a write whose ETag has moved, and the backend re-reads
+and reapplies this run's documents on top of the other writer's. The
+cost of the bundle is that a minute which changed one Snapshot rewrites
+every big document with it; the benefit is one request instead of nine,
+and a stored set that is always internally consistent.
+
+Reapplying is only sound where the other writer left this run's
+documents alone. Where both changed the same one - the Event Log is the
+only realistic case - this run's value was derived from a version that
+no longer exists, and writing it would drop the user's tap. There is no
+general way to merge two documents at this level, so the backend
+compares each document against what it held when the run first touched
+it and refuses loudly when that has moved. The Check then errors, the
+error alarm sees it, and the next minute's run reads the Event Log with
+the tap already in it. Losing one Check is cheap; losing a Done tap
+means re-alerting a problem the user has already dealt with.
+
+The batching costs one guarantee the file storage gave. An Alert is
+sent to Telegram during the run, and the Event Log entry that dedups it
+is stored at the end, so a crash between the two re-sends that Alert
+next minute. That window is the price of the spec's "batched into one
+object", and it is the same class of problem as issue #37, which is
+open on whether Alert delivery needs an outbox. It is recorded here
+rather than solved here.
+
+The small records write straight through. They are small and few, so
+batching would buy nothing and would cost the guarantee that an Alert
+id is stored before the Alert goes out. Reads are strongly consistent,
+because the webhook writes what the next Check reads a moment later.
+
+`JsonStore` stays the seam every caller holds. It now owns only the
+JSON, and hands bytes to a `DocumentBackend` - the local file tree or
+the AWS pair. No caller changed.
+
+## Secrets are read once, at init
+
+The bot token, the chat id, the webhook secret and the model key are
+SSM Parameter Store SecureStrings under one path. `SsmSecrets` is an
+`EnvironmentPostProcessor`: it runs before the context is built, so the
+values are already in the environment the beans read, and under
+SnapStart they are inside the restored snapshot. A parameter's leaf
+name is the property it sets, so adding a secret needs no code.
+
+The cost is the point of the design, and it is real: rotating a secret
+needs a new function version, not just a new parameter value. That is
+the right trade for four secrets that change about never, against
+paying for a Parameter Store read on every Check.
+
+Parameter Store rather than Secrets Manager: SecureStrings are free,
+hold as much, and rotate by hand either way for a personal bot.
+
+The lookup is triggered by the parameter path, not by the profile.
+Profiles settle later than an `EnvironmentPostProcessor` runs, and a
+laptop that quietly reached for Parameter Store would be found out only
+when a message failed to send.
+
+## The assistant reports on itself
+
+CloudWatch logs keep 14 days. Two alarms feed one SNS topic, and the
+topic reaches the user twice: email, which keeps, and a forwarder
+Lambda that posts to the Telegram chat, which the user reads in time.
+
+The forwarder is its own function on purpose. What it reports on is the
+assistant being broken, and a forwarder living inside the assistant
+would be broken with it.
+
+The error alarm counts `ERROR` lines in both application log groups.
+The heartbeat alarm counts one line every Check logs, and treats
+missing data as breaching - a Check loop that stopped is the failure
+the user would otherwise never see, because nothing errors and the
+assistant simply goes quiet. The marker is logged whether or not the
+pre-draft cadence let the Check do any work: a Check that ran is a loop
+that is alive.
+
+Both alarms are log metric filters rather than a metric the app puts.
+That keeps `PutMetricData` off every function's policy and keeps the
+app free of any code that exists only to be watched.
+
+The bucket keeps versions and the table keeps point-in-time recovery.
+Neither was asked for, and both are kept deliberately: one object holds
+the whole season's record, so a single bad write could take all of it,
+and a version is what that is recovered from. Because the object is
+rewritten every minute, a lifecycle rule expires noncurrent versions
+after seven days - long enough to notice and roll back, short of the
+44,000 versions a month the bucket would otherwise keep.
+
+A monthly Budget watches the spend against $20 and warns at 80% of
+actual and at a forecast that would pass 100%. The assistant serves one
+user, so a bill that climbs is a bug, not growth.
+
+It is worth being exact about what a Budget does, because the name
+invites the wrong reading: it notifies, and it does not stop spending.
+Nothing in AWS caps a Lambda, an S3 request or a DynamoDB write by
+money. The things that actually bound the spend here are the reserved
+concurrency on the scheduled function, the 14-day log retention, and
+the bucket's lifecycle rule. The Budget is how the operator finds out
+that one of those three has failed.
+
+## What the stack deliberately does not contain
+
+Each of these was considered and left out:
+
+- **API Gateway** - a function URL is the whole front door one bot needs.
+- **Secrets Manager** - Parameter Store SecureStrings cost nothing and hold as much.
+- **RDS, and a VPC** - there is no database, and nothing private to reach.
+- **ECS, Fargate, App Runner** - nothing runs between Checks.
+- **SQS, Step Functions** - the Event Log already sequences the work.
+- **Terraform, SAM** - CDK in the app's own language, so one build and one review cover both.
+- **A dev stage** - one user, one league, one place for it to run.
+
+`OttoStackTest` asserts the absence of each, so removing one by
+accident is a failing test rather than a surprise bill.
+
+## The IaC is one CDK stack in Java
+
+One stack, in the language the app is written in, tested by synthesizing
+the template and reading the ticket's acceptance criteria back off it.
+The stack lives in `infra/` with its own build, because the app's
+deployable must not carry the CDK libraries.
+
+IAM is least-privilege per function. The bucket grant names the one
+object key the app writes, so a function that went wrong could not fill
+the bucket with anything else. The forwarder reads secrets and nothing
+else.

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -1,0 +1,142 @@
+# Deploy
+
+How to put the assistant in the cloud and how to prove it is awake.
+
+You need the AWS CLI signed in to the account you want, Node (for the
+CDK CLI), JDK 25, and Maven. The stack goes to `us-east-1`.
+
+## 1. Store the secrets
+
+CloudFormation cannot create a SecureString, so the four secrets are
+put by hand, once. The leaf of each parameter name is the property it
+sets, so the spelling matters.
+
+```sh
+PATH_PREFIX=/otto/prod
+
+for pair in \
+  "otto.telegram.bot-token:$TELEGRAM_BOT_TOKEN" \
+  "otto.telegram.chat-id:$TELEGRAM_CHAT_ID" \
+  "otto.telegram.webhook-secret:$TELEGRAM_WEBHOOK_SECRET" \
+  "spring.ai.openai.api-key:$OPENAI_API_KEY"
+do
+  aws ssm put-parameter --region us-east-1 --type SecureString --overwrite \
+    --name "$PATH_PREFIX/${pair%%:*}" --value "${pair#*:}"
+done
+```
+
+Pick the webhook secret yourself. It is any string of 1 to 256
+characters from `A-Z a-z 0-9 _ -`; Telegram echoes it on every call and
+the assistant refuses a call without it.
+
+## 2. Build the deployable
+
+The stack uploads `target/otto-lambda.zip`, so build it first.
+
+```sh
+mvn package     # needs JDK 25 on JAVA_HOME
+```
+
+## 3. Deploy the stack
+
+Every CDK command runs from `infra/`, which is where `cdk.json` says how
+to synthesize the stack.
+
+```sh
+cd infra
+npx aws-cdk@2 bootstrap aws://ACCOUNT_ID/us-east-1   # once per account
+npx aws-cdk@2 deploy -c alertEmail=you@example.com
+```
+
+The stack takes `alertEmail` and refuses to synthesize without it - an
+assistant that cannot report on itself is worse than one that is not
+deployed. Two optional context values: `parameterPath` (default
+`/otto/prod`) and `timeZone` (default `America/Los_Angeles`, which is
+when the nightly defense-versus-position build runs).
+
+Confirm the SNS subscription in the email AWS sends, or no alarm will
+reach you.
+
+CDK warns twice that "SnapStart only supports published Lambda
+versions". Expect it: the check cannot see that both functions are
+reached through an alias on a published version, which they are.
+
+## 4. Point Telegram at the webhook
+
+The deploy prints `WebhookUrl`. Telegram delivers to a webhook or to
+`getUpdates`, never to both, so registering this one stops any local
+run from reading messages.
+
+```sh
+curl -s "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/setWebhook" \
+  -d "url=${WEBHOOK_URL}" \
+  -d "secret_token=${TELEGRAM_WEBHOOK_SECRET}" \
+  -d 'allowed_updates=["message","callback_query"]'
+```
+
+To go back to running on your own machine, clear it:
+
+```sh
+curl -s "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/deleteWebhook"
+```
+
+## 5. Verify it live
+
+Four checks, in order. The first three take a few minutes; the fourth
+takes fifteen.
+
+**The Check loop runs.** Watch the scheduled function's log for the
+heartbeat line:
+
+```sh
+aws logs tail --region us-east-1 --follow \
+  "$(aws cloudformation describe-stack-resources --stack-name OttoStack \
+      --query "StackResources[?LogicalResourceId=='ScheduledLogs'].PhysicalResourceId" \
+      --output text)"
+```
+
+One `heartbeat check-completed` a minute is the loop alive.
+
+**The Ask loop answers.** Text the bot. A reply means the function URL,
+the secret token, the chat gate, the model key and the stored
+conversation all work.
+
+**A self-report Alert arrives.** Break one feed on purpose and let one
+Check run into it - point `otto.sleeper.base-url` at a host that
+refuses, or revoke the model key - and the assistant should text you
+that it cannot read that source. Put the setting back afterwards. This
+is the Alert that tells you the assistant knows when it is blind, so it
+is worth proving once rather than trusting.
+
+**The heartbeat alarm fires.** Disable the 1-minute Check schedule and
+wait fifteen minutes. Easiest in the EventBridge Scheduler console:
+find the schedule whose name contains `CheckSchedule` and disable it.
+
+By CLI it takes two steps, because `update-schedule` replaces the whole
+schedule rather than patching one field, so the definition has to be
+read back first:
+
+```sh
+NAME=$(aws scheduler list-schedules --region us-east-1 \
+  --query "Schedules[?contains(Name,'CheckSchedule')].Name" --output text)
+
+aws scheduler get-schedule --region us-east-1 --name "$NAME" \
+  --query '{Name:Name,GroupName:GroupName,ScheduleExpression:ScheduleExpression,FlexibleTimeWindow:FlexibleTimeWindow,Target:Target,State:`DISABLED`}' \
+  > /tmp/check-schedule.json
+
+aws scheduler update-schedule --region us-east-1 \
+  --cli-input-json file:///tmp/check-schedule.json
+```
+
+The alarm should go to ALARM, the email should arrive, and the
+forwarder should text you. Put it back by repeating the two commands
+with `` `ENABLED` `` in place of `` `DISABLED` ``. Until this one has
+fired once, you do not know the assistant can tell you it has stopped.
+
+## What it costs
+
+Under the $20 monthly budget the stack sets, and well under it in
+practice: about 44,000 Lambda invocations a month at 1024 MB for a few
+seconds each, one S3 object written per minute, a few DynamoDB reads
+and writes per run, and the model calls the Ask loop makes. The budget
+warns at 80% of actual spend and at a forecast that would pass $20.

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -1,19 +1,16 @@
 # Deploy
 
-How to put the assistant in the cloud and how to prove it is awake.
+One CDK stack deploys the whole assistant to `us-east-1`.
 
-You need the AWS CLI signed in to the account you want, Node (for the
-CDK CLI), JDK 25, and Maven. The stack goes to `us-east-1`.
+You need the AWS CLI signed in, Node, JDK 25 and Maven.
 
 ## 1. Store the secrets
 
-CloudFormation cannot create a SecureString, so the four secrets are
-put by hand, once. The leaf of each parameter name is the property it
-sets, so the spelling matters.
+CloudFormation cannot create encrypted parameters, so these are set once
+by hand. The name after the path is the property it sets, so the
+spelling matters.
 
 ```sh
-PATH_PREFIX=/otto/prod
-
 for pair in \
   "otto.telegram.bot-token:$TELEGRAM_BOT_TOKEN" \
   "otto.telegram.chat-id:$TELEGRAM_CHAT_ID" \
@@ -21,51 +18,38 @@ for pair in \
   "spring.ai.openai.api-key:$OPENAI_API_KEY"
 do
   aws ssm put-parameter --region us-east-1 --type SecureString --overwrite \
-    --name "$PATH_PREFIX/${pair%%:*}" --value "${pair#*:}"
+    --name "/otto/prod/${pair%%:*}" --value "${pair#*:}"
 done
 ```
 
-Pick the webhook secret yourself. It is any string of 1 to 256
-characters from `A-Z a-z 0-9 _ -`; Telegram echoes it on every call and
-the assistant refuses a call without it.
+Choose the webhook secret yourself - any string of `A-Z a-z 0-9 _ -`.
+Telegram echoes it on every call, and the assistant refuses a call
+without it.
 
-## 2. Build the deployable
-
-The stack uploads `target/otto-lambda.zip`, so build it first.
+## 2. Deploy
 
 ```sh
-mvn package     # needs JDK 25 on JAVA_HOME
-```
-
-## 3. Deploy the stack
-
-Every CDK command runs from `infra/`, which is where `cdk.json` says how
-to synthesize the stack.
-
-```sh
+mvn package                                          # builds the Lambda zip
 cd infra
 npx aws-cdk@2 bootstrap aws://ACCOUNT_ID/us-east-1   # once per account
 npx aws-cdk@2 deploy -c alertEmail=you@example.com
 ```
 
-The stack takes `alertEmail` and refuses to synthesize without it - an
-assistant that cannot report on itself is worse than one that is not
-deployed. Two optional context values: `parameterPath` (default
-`/otto/prod`) and `timeZone` (default `America/Los_Angeles`, which is
-when the nightly defense-versus-position build runs).
+`alertEmail` is required and the stack will not synthesize without it.
+Optional: `parameterPath` (default `/otto/prod`) and `timeZone` (default
+`America/Los_Angeles`, when the nightly build runs).
 
-Confirm the SNS subscription in the email AWS sends, or no alarm will
-reach you.
+Confirm the subscription email AWS sends, or no alarm will reach you.
 
-CDK warns twice that "SnapStart only supports published Lambda
-versions". Expect it: the check cannot see that both functions are
-reached through an alias on a published version, which they are.
+**On a new AWS account**, add `-c scheduledReservedConcurrency=0`. New
+accounts are capped at 10 concurrent Lambda executions, and AWS refuses
+a reservation that would leave fewer than 10 unreserved - so none can be
+made. Request a quota increase for Lambda concurrent executions, then
+redeploy without the flag to limit the Check to one run at a time.
 
-## 4. Point Telegram at the webhook
+## 3. Point Telegram at the webhook
 
-The deploy prints `WebhookUrl`. Telegram delivers to a webhook or to
-`getUpdates`, never to both, so registering this one stops any local
-run from reading messages.
+The deploy prints `WebhookUrl`.
 
 ```sh
 curl -s "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/setWebhook" \
@@ -74,69 +58,17 @@ curl -s "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/setWebhook" \
   -d 'allowed_updates=["message","callback_query"]'
 ```
 
-To go back to running on your own machine, clear it:
+Telegram delivers to a webhook or to `getUpdates`, never both, so this
+stops a local run from reading messages. To go back to running locally,
+call `deleteWebhook`.
 
-```sh
-curl -s "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/deleteWebhook"
-```
+## 4. Check it works
 
-## 5. Verify it live
-
-Four checks, in order. The first three take a few minutes; the fourth
-takes fifteen.
-
-**The Check loop runs.** Watch the scheduled function's log for the
-heartbeat line:
-
-```sh
-aws logs tail --region us-east-1 --follow \
-  "$(aws cloudformation describe-stack-resources --stack-name OttoStack \
-      --query "StackResources[?LogicalResourceId=='ScheduledLogs'].PhysicalResourceId" \
-      --output text)"
-```
-
-One `heartbeat check-completed` a minute is the loop alive.
-
-**The Ask loop answers.** Text the bot. A reply means the function URL,
-the secret token, the chat gate, the model key and the stored
-conversation all work.
-
-**A self-report Alert arrives.** Break one feed on purpose and let one
-Check run into it - point `otto.sleeper.base-url` at a host that
-refuses, or revoke the model key - and the assistant should text you
-that it cannot read that source. Put the setting back afterwards. This
-is the Alert that tells you the assistant knows when it is blind, so it
-is worth proving once rather than trusting.
-
-**The heartbeat alarm fires.** Disable the 1-minute Check schedule and
-wait fifteen minutes. Easiest in the EventBridge Scheduler console:
-find the schedule whose name contains `CheckSchedule` and disable it.
-
-By CLI it takes two steps, because `update-schedule` replaces the whole
-schedule rather than patching one field, so the definition has to be
-read back first:
-
-```sh
-NAME=$(aws scheduler list-schedules --region us-east-1 \
-  --query "Schedules[?contains(Name,'CheckSchedule')].Name" --output text)
-
-aws scheduler get-schedule --region us-east-1 --name "$NAME" \
-  --query '{Name:Name,GroupName:GroupName,ScheduleExpression:ScheduleExpression,FlexibleTimeWindow:FlexibleTimeWindow,Target:Target,State:`DISABLED`}' \
-  > /tmp/check-schedule.json
-
-aws scheduler update-schedule --region us-east-1 \
-  --cli-input-json file:///tmp/check-schedule.json
-```
-
-The alarm should go to ALARM, the email should arrive, and the
-forwarder should text you. Put it back by repeating the two commands
-with `` `ENABLED` `` in place of `` `DISABLED` ``. Until this one has
-fired once, you do not know the assistant can tell you it has stopped.
-
-## What it costs
-
-Under the $20 monthly budget the stack sets, and well under it in
-practice: about 44,000 Lambda invocations a month at 1024 MB for a few
-seconds each, one S3 object written per minute, a few DynamoDB reads
-and writes per run, and the model calls the Ask loop makes. The budget
-warns at 80% of actual spend and at a forecast that would pass $20.
+- **The Check loop.** Tail the scheduled function's log group.
+  `heartbeat check-completed` should appear once a minute.
+- **The Ask loop.** Text the bot. A reply exercises the function URL, the
+  secret token, the chat gate and the model.
+- **The alarm.** Disable `CheckSchedule` in the EventBridge Scheduler
+  console and wait fifteen minutes. An email and a Telegram message
+  should arrive. Re-enable it afterwards. Until it has fired once, you do
+  not know the assistant can tell you it has stopped.

--- a/infra/cdk.json
+++ b/infra/cdk.json
@@ -1,0 +1,9 @@
+{
+  "app": "mvn -e -q compile exec:java",
+  "context": {
+    "parameterPath": "/otto/prod",
+    "timeZone": "America/Los_Angeles",
+    "@aws-cdk/core:checkSecretUsage": true,
+    "@aws-cdk/aws-iam:minimizePolicies": true
+  }
+}

--- a/infra/pom.xml
+++ b/infra/pom.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>otto</groupId>
+  <artifactId>otto-infra</artifactId>
+  <version>0.1.0-SNAPSHOT</version>
+  <name>otto-infra</name>
+  <description>The one CDK stack that deploys the assistant</description>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.release>25</maven.compiler.release>
+    <cdk.version>2.263.0</cdk.version>
+    <constructs.version>10.8.1</constructs.version>
+    <junit.version>5.14.1</junit.version>
+    <assertj.version>3.27.6</assertj.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>software.amazon.awscdk</groupId>
+      <artifactId>aws-cdk-lib</artifactId>
+      <version>${cdk.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>software.constructs</groupId>
+      <artifactId>constructs</artifactId>
+      <version>${constructs.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <version>${junit.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <version>${assertj.version}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.13.0</version>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>3.5.2</version>
+      </plugin>
+      <!-- What "cdk synth" runs to produce the template. -->
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
+        <version>3.5.0</version>
+        <configuration>
+          <mainClass>otto.infra.OttoApp</mainClass>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/infra/src/main/java/otto/infra/OttoApp.java
+++ b/infra/src/main/java/otto/infra/OttoApp.java
@@ -1,0 +1,35 @@
+package otto.infra;
+
+import software.amazon.awscdk.App;
+import software.amazon.awscdk.Environment;
+import software.amazon.awscdk.StackProps;
+
+/**
+ * The CDK entry point. One app, one stack, one region: the assistant
+ * serves one league for one user, and a second stage would be a second
+ * thing to keep alive for no one's benefit.
+ */
+public final class OttoApp {
+
+    /**
+     * us-east-1, as the spec names. The Sleeper and nflverse hosts are
+     * public and the user is not in the region, so the region is chosen
+     * for the widest service coverage rather than for latency.
+     */
+    private static final String REGION = "us-east-1";
+
+    private OttoApp() {
+    }
+
+    public static void main(String[] args) {
+        App app = new App();
+        new OttoStack(app, "OttoStack", StackProps.builder()
+                .description("Otto, the fantasy football assistant")
+                .env(Environment.builder()
+                        .account(System.getenv("CDK_DEFAULT_ACCOUNT"))
+                        .region(REGION)
+                        .build())
+                .build());
+        app.synth();
+    }
+}

--- a/infra/src/main/java/otto/infra/OttoStack.java
+++ b/infra/src/main/java/otto/infra/OttoStack.java
@@ -1,0 +1,456 @@
+package otto.infra;
+
+import java.util.List;
+import java.util.Map;
+
+import software.amazon.awscdk.CfnOutput;
+import software.amazon.awscdk.Duration;
+import software.amazon.awscdk.RemovalPolicy;
+import software.amazon.awscdk.Stack;
+import software.amazon.awscdk.StackProps;
+import software.amazon.awscdk.services.budgets.CfnBudget;
+import software.amazon.awscdk.services.cloudwatch.Alarm;
+import software.amazon.awscdk.services.cloudwatch.ComparisonOperator;
+import software.amazon.awscdk.services.cloudwatch.Metric;
+import software.amazon.awscdk.services.cloudwatch.TreatMissingData;
+import software.amazon.awscdk.services.cloudwatch.actions.SnsAction;
+import software.amazon.awscdk.services.dynamodb.Attribute;
+import software.amazon.awscdk.services.dynamodb.AttributeType;
+import software.amazon.awscdk.services.dynamodb.BillingMode;
+import software.amazon.awscdk.services.dynamodb.PointInTimeRecoverySpecification;
+import software.amazon.awscdk.services.dynamodb.Table;
+import software.amazon.awscdk.services.dynamodb.TableEncryption;
+import software.amazon.awscdk.services.iam.Effect;
+import software.amazon.awscdk.services.iam.PolicyStatement;
+import software.amazon.awscdk.services.iam.Role;
+import software.amazon.awscdk.services.iam.ServicePrincipal;
+import software.amazon.awscdk.services.lambda.Alias;
+import software.amazon.awscdk.services.lambda.Architecture;
+import software.amazon.awscdk.services.lambda.Code;
+import software.amazon.awscdk.services.lambda.Function;
+import software.amazon.awscdk.services.lambda.FunctionUrl;
+import software.amazon.awscdk.services.lambda.FunctionUrlAuthType;
+import software.amazon.awscdk.services.lambda.FunctionUrlOptions;
+import software.amazon.awscdk.services.lambda.Runtime;
+import software.amazon.awscdk.services.lambda.SnapStartConf;
+import software.amazon.awscdk.services.logs.FilterPattern;
+import software.amazon.awscdk.services.logs.LogGroup;
+import software.amazon.awscdk.services.logs.MetricFilter;
+import software.amazon.awscdk.services.logs.RetentionDays;
+import software.amazon.awscdk.services.s3.BlockPublicAccess;
+import software.amazon.awscdk.services.s3.Bucket;
+import software.amazon.awscdk.services.s3.BucketEncryption;
+import software.amazon.awscdk.services.s3.LifecycleRule;
+import software.amazon.awscdk.services.scheduler.CfnSchedule;
+import software.amazon.awscdk.services.sns.Topic;
+import software.amazon.awscdk.services.sns.subscriptions.EmailSubscription;
+import software.amazon.awscdk.services.sns.subscriptions.LambdaSubscription;
+import software.constructs.Construct;
+
+/**
+ * The whole assistant, in one stack.
+ *
+ * <p>Two entry points carry the app: a scheduled function that runs
+ * the Check and the two nflverse jobs, and a webhook function behind a
+ * Lambda function URL that Telegram posts to. Both are the same
+ * deployable with a different handler, and both run on a published
+ * version through an alias, because SnapStart restores versions and
+ * never $LATEST.
+ *
+ * <p>Deliberately absent, and each for a reason: API Gateway (a
+ * function URL is the whole front door one bot needs), Secrets Manager
+ * (Parameter Store SecureStrings cost nothing and hold as much), RDS
+ * and a VPC (there is no database and nothing private to reach),
+ * ECS/Fargate and App Runner (nothing runs between Checks), SQS and
+ * Step Functions (the Event Log already sequences the work), Terraform
+ * and SAM (CDK in the app's own language), and a dev stage (one user,
+ * one league, one place for it to run).
+ */
+public class OttoStack extends Stack {
+
+    /** Built by "mvn package" in the repo root, before "cdk deploy". */
+    private static final String LAMBDA_ASSET = "../target/otto-lambda.zip";
+
+    private static final Runtime RUNTIME = Runtime.JAVA_25;
+    private static final Architecture ARCHITECTURE = Architecture.ARM_64;
+    private static final Number MEMORY_MB = 1024;
+
+    /**
+     * The nightly defense-versus-position build reads a season of
+     * nflverse rows, which is the longest thing the assistant does. A
+     * Check is seconds; the timeout is sized for the slowest job.
+     */
+    private static final Duration SCHEDULED_TIMEOUT = Duration.seconds(300);
+
+    /** A webhook answer is one model call and one message out. */
+    private static final Duration WEBHOOK_TIMEOUT = Duration.seconds(60);
+
+    private static final RetentionDays LOG_RETENTION = RetentionDays.TWO_WEEKS;
+
+    /** Where the alarms read their counts from. */
+    private static final String METRIC_NAMESPACE = "Otto";
+
+    /**
+     * The one object every big document lives in. The app spells this
+     * too, in {@code S3BundleBackend}, and cannot share the constant
+     * across the two builds. It is here to keep the bucket grant down
+     * to the one key the app writes; a drift between the two shows up
+     * as a denied write on the first Check after a deploy.
+     */
+    private static final String DOCUMENTS_KEY = "documents.json";
+
+    /** What one month of this is allowed to cost. */
+    private static final Number MONTHLY_BUDGET_USD = 20;
+
+    public OttoStack(Construct scope, String id, StackProps props) {
+        super(scope, id, props);
+
+        String parameterPath = context("parameterPath", "/otto/prod");
+        String timeZone = context("timeZone", "America/Los_Angeles");
+        String alertEmail = requiredContext("alertEmail");
+
+        Bucket documents = documentsBucket();
+        Table records = recordsTable();
+
+        Map<String, String> environment = Map.of(
+                "SPRING_PROFILES_ACTIVE", "aws",
+                "OTTO_BUCKET", documents.getBucketName(),
+                "OTTO_TABLE", records.getTableName(),
+                "OTTO_PARAMETER_PATH", parameterPath);
+
+        LogGroup scheduledLogs = logGroup("ScheduledLogs");
+        // One scheduled run at a time. Two overlapping runs would read
+        // the same stored documents, and the second would spend a
+        // conflict retry rewriting what the first had just written.
+        Function scheduled = appFunction("Scheduled", "otto.aws.ScheduledHandler",
+                SCHEDULED_TIMEOUT, scheduledLogs, environment, 1);
+        Alias scheduledLive = alias("ScheduledLive", scheduled);
+
+        LogGroup webhookLogs = logGroup("WebhookLogs");
+        Function webhook = appFunction("Webhook", "otto.aws.WebhookHandler",
+                WEBHOOK_TIMEOUT, webhookLogs, environment, null);
+        Alias webhookLive = alias("WebhookLive", webhook);
+
+        readWriteStorage(documents, records, scheduled);
+        readWriteStorage(documents, records, webhook);
+        readSecrets(scheduled, parameterPath);
+        readSecrets(webhook, parameterPath);
+
+        schedules(scheduledLive, timeZone);
+        FunctionUrl webhookUrl = webhookLive.addFunctionUrl(FunctionUrlOptions.builder()
+                // Telegram signs nothing AWS can check. The secret token
+                // it echoes is the guard, and the seam checks it.
+                .authType(FunctionUrlAuthType.NONE)
+                .build());
+
+        LogGroup forwarderLogs = logGroup("AlarmForwarderLogs");
+        Topic alarms = alarmTopic(alertEmail, environment, parameterPath, forwarderLogs);
+        // The forwarder is watched too. It is the part that tells the
+        // user an alarm fired, so it failing quietly would cost every
+        // other alarm its voice.
+        errorAlarm(alarms, Map.of(
+                "Scheduled", scheduledLogs,
+                "Webhook", webhookLogs,
+                "AlarmForwarder", forwarderLogs));
+        heartbeatAlarm(alarms, scheduledLogs);
+        budget(alertEmail);
+
+        CfnOutput.Builder.create(this, "WebhookUrl")
+                .value(webhookUrl.getUrl())
+                .description("Register this with Telegram setWebhook, with the secret token")
+                .build();
+        CfnOutput.Builder.create(this, "DocumentsBucket")
+                .value(documents.getBucketName())
+                .description("The big documents, as one object")
+                .build();
+        CfnOutput.Builder.create(this, "RecordsTable")
+                .value(records.getTableName())
+                .description("The small records, one item each")
+                .build();
+    }
+
+    private Bucket documentsBucket() {
+        return Bucket.Builder.create(this, "Documents")
+                .encryption(BucketEncryption.S3_MANAGED)
+                .blockPublicAccess(BlockPublicAccess.BLOCK_ALL)
+                .enforceSsl(true)
+                // A season of Snapshots and the Event Log are the only
+                // record of what the assistant has seen, and one object
+                // holds all of it, so one bad write could take the lot.
+                // Versions are what a bad write is recovered from.
+                .versioned(true)
+                // The object is rewritten every minute, so without this
+                // the bucket would keep about 44,000 versions a month.
+                // A week is long enough to notice and roll back.
+                .lifecycleRules(List.of(LifecycleRule.builder()
+                        .id("expire-old-versions")
+                        .noncurrentVersionExpiration(Duration.days(7))
+                        .abortIncompleteMultipartUploadAfter(Duration.days(1))
+                        .build()))
+                .removalPolicy(RemovalPolicy.RETAIN)
+                .build();
+    }
+
+    private Table recordsTable() {
+        return Table.Builder.create(this, "Records")
+                .partitionKey(Attribute.builder()
+                        .name("name")
+                        .type(AttributeType.STRING)
+                        .build())
+                .billingMode(BillingMode.PAY_PER_REQUEST)
+                .encryption(TableEncryption.AWS_MANAGED)
+                .pointInTimeRecoverySpecification(PointInTimeRecoverySpecification.builder()
+                        .pointInTimeRecoveryEnabled(true)
+                        .build())
+                .removalPolicy(RemovalPolicy.RETAIN)
+                .build();
+    }
+
+    private LogGroup logGroup(String id) {
+        return LogGroup.Builder.create(this, id)
+                .retention(LOG_RETENTION)
+                .removalPolicy(RemovalPolicy.DESTROY)
+                .build();
+    }
+
+    private Function appFunction(String id, String handler, Duration timeout,
+            LogGroup logs, Map<String, String> environment, Number reservedConcurrency) {
+        return Function.Builder.create(this, id)
+                .reservedConcurrentExecutions(reservedConcurrency)
+                .runtime(RUNTIME)
+                .architecture(ARCHITECTURE)
+                .handler(handler)
+                .code(Code.fromAsset(LAMBDA_ASSET))
+                .memorySize(MEMORY_MB)
+                .timeout(timeout)
+                .environment(environment)
+                .logGroup(logs)
+                // The Spring context is built while the class loads, so
+                // the snapshot holds a started app and a restore answers
+                // without paying for a start.
+                .snapStart(SnapStartConf.ON_PUBLISHED_VERSIONS)
+                .build();
+    }
+
+    private Alias alias(String id, Function function) {
+        return Alias.Builder.create(this, id)
+                .aliasName("live")
+                .version(function.getCurrentVersion())
+                .build();
+    }
+
+    /**
+     * One object and one table, and nothing else in either service. The
+     * bucket grant names the one key the app writes, so a function that
+     * went wrong could not fill the bucket with anything else.
+     */
+    private void readWriteStorage(Bucket documents, Table records, Function function) {
+        documents.grantReadWrite(function, DOCUMENTS_KEY);
+        records.grantReadWriteData(function);
+    }
+
+    private void readSecrets(Function function, String parameterPath) {
+        function.addToRolePolicy(PolicyStatement.Builder.create()
+                .effect(Effect.ALLOW)
+                .actions(List.of("ssm:GetParameter", "ssm:GetParameters",
+                        "ssm:GetParametersByPath"))
+                // The partition comes from the stack rather than the
+                // literal "aws", so the ARN is built the same way CDK
+                // builds its own and does not assume a commercial region.
+                .resources(List.of("arn:%s:ssm:%s:%s:parameter%s/*"
+                        .formatted(getPartition(), getRegion(), getAccount(), parameterPath)))
+                .build());
+    }
+
+    /**
+     * The three schedules the spec names. Everything else the assistant
+     * does on a clock - the Lock Ladder, the Tuesday waiver Alert, the
+     * 20-minute Done follow-up - derives from the 1-minute loop and the
+     * Event Log, and has no schedule here to drift out of step with it.
+     */
+    private void schedules(Alias target, String timeZone) {
+        Role invoker = Role.Builder.create(this, "SchedulerRole")
+                .assumedBy(new ServicePrincipal("scheduler.amazonaws.com"))
+                .build();
+        target.grantInvoke(invoker);
+
+        // A missed Check is not worth retrying: the next tick is the
+        // retry, one minute away. The two nflverse jobs come round once
+        // an hour and once a night, so a run lost to the one-at-a-time
+        // limit would leave the feeds stale for that long; they retry.
+        schedule("CheckSchedule", target, invoker, "rate(1 minute)", null, "check", 0);
+        schedule("NflverseFeedsSchedule", target, invoker, "rate(1 hour)", null,
+                "nflverse-feeds", 3);
+        // After the last game of any night and before the user's morning.
+        schedule("DefenseVersusPositionSchedule", target, invoker, "cron(30 3 * * ? *)",
+                timeZone, "defense-versus-position", 5);
+    }
+
+    private void schedule(String id, Alias target, Role invoker, String expression,
+            String timeZone, String job, Number retries) {
+        CfnSchedule.Builder builder = CfnSchedule.Builder.create(this, id)
+                .flexibleTimeWindow(CfnSchedule.FlexibleTimeWindowProperty.builder()
+                        .mode("OFF")
+                        .build())
+                .scheduleExpression(expression)
+                .target(CfnSchedule.TargetProperty.builder()
+                        .arn(target.getFunctionArn())
+                        .roleArn(invoker.getRoleArn())
+                        .input("{\"job\":\"%s\"}".formatted(job))
+                        .retryPolicy(CfnSchedule.RetryPolicyProperty.builder()
+                                .maximumRetryAttempts(retries)
+                                .build())
+                        .build());
+        if (timeZone != null) {
+            builder.scheduleExpressionTimezone(timeZone);
+        }
+        builder.build();
+    }
+
+    /**
+     * Where an alarm goes: email, which keeps, and Telegram, which the
+     * user reads in time. The forwarder is its own function, because
+     * what it reports on is the assistant being down.
+     */
+    private Topic alarmTopic(String alertEmail, Map<String, String> environment,
+            String parameterPath, LogGroup forwarderLogs) {
+        Topic topic = Topic.Builder.create(this, "Alarms")
+                .displayName("Otto alarms")
+                .build();
+        topic.addSubscription(new EmailSubscription(alertEmail));
+
+        Function forwarder = Function.Builder.create(this, "AlarmForwarder")
+                .runtime(RUNTIME)
+                .architecture(ARCHITECTURE)
+                .handler("otto.aws.AlarmForwarderHandler")
+                .code(Code.fromAsset(LAMBDA_ASSET))
+                .memorySize(MEMORY_MB)
+                // No SnapStart here: alarms are rare, so this one pays a
+                // cold Spring start rather than carrying a version and an
+                // alias for the sake of a few seconds nobody waits on.
+                .timeout(Duration.seconds(60))
+                .environment(environment)
+                .logGroup(forwarderLogs)
+                .build();
+        readSecrets(forwarder, parameterPath);
+        topic.addSubscription(new LambdaSubscription(forwarder));
+        return topic;
+    }
+
+    private void errorAlarm(Topic alarms, Map<String, LogGroup> logs) {
+        // Each filter is named after the log group it reads, so adding
+        // or removing one never renames another's resource.
+        logs.forEach((name, group) -> MetricFilter.Builder.create(this, name + "ErrorFilter")
+                .logGroup(group)
+                .filterPattern(FilterPattern.literal("\"ERROR\""))
+                .metricNamespace(METRIC_NAMESPACE)
+                .metricName("Errors")
+                .metricValue("1")
+                .defaultValue(0)
+                .build());
+        alarm("ErrorAlarm", alarms, Metric.Builder.create()
+                        .namespace(METRIC_NAMESPACE)
+                        .metricName("Errors")
+                        .statistic("Sum")
+                        .period(Duration.minutes(5))
+                        .build(),
+                1, ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+                TreatMissingData.NOT_BREACHING,
+                "Otto logged an error");
+    }
+
+    /**
+     * A Check loop that stopped is the failure the user would otherwise
+     * never see: nothing errors, the assistant simply goes quiet. Every
+     * Check logs one line, and missing data breaches - a function that
+     * stopped being invoked logs nothing at all.
+     */
+    private void heartbeatAlarm(Topic alarms, LogGroup scheduledLogs) {
+        MetricFilter.Builder.create(this, "HeartbeatFilter")
+                .logGroup(scheduledLogs)
+                .filterPattern(FilterPattern.literal("\"heartbeat check-completed\""))
+                .metricNamespace(METRIC_NAMESPACE)
+                .metricName("CheckCompleted")
+                .metricValue("1")
+                .defaultValue(0)
+                .build();
+        alarm("HeartbeatAlarm", alarms, Metric.Builder.create()
+                        .namespace(METRIC_NAMESPACE)
+                        .metricName("CheckCompleted")
+                        .statistic("Sum")
+                        .period(Duration.minutes(15))
+                        .build(),
+                1, ComparisonOperator.LESS_THAN_THRESHOLD, TreatMissingData.BREACHING,
+                "The Check loop has run nothing for 15 minutes");
+    }
+
+    private void alarm(String id, Topic alarms, Metric metric, Number threshold,
+            ComparisonOperator comparison, TreatMissingData missing, String description) {
+        Alarm alarm = Alarm.Builder.create(this, id)
+                .metric(metric)
+                .threshold(threshold)
+                .comparisonOperator(comparison)
+                .evaluationPeriods(1)
+                .treatMissingData(missing)
+                .alarmDescription(description)
+                .build();
+        alarm.addAlarmAction(new SnsAction(alarms));
+    }
+
+    /**
+     * What the whole thing is expected to cost. The assistant serves one
+     * user, so a bill that climbs is a bug, not growth.
+     *
+     * <p>A Budget notifies and does not cap: no AWS setting stops a
+     * Lambda or an S3 request by money. What bounds the spend here is
+     * the reserved concurrency, the log retention and the bucket's
+     * lifecycle rule. This is how the operator hears that one of the
+     * three stopped working.
+     */
+    private void budget(String alertEmail) {
+        CfnBudget.Builder.create(this, "Budget")
+                .budget(CfnBudget.BudgetDataProperty.builder()
+                        .budgetName("otto-monthly")
+                        .budgetType("COST")
+                        .timeUnit("MONTHLY")
+                        .budgetLimit(CfnBudget.SpendProperty.builder()
+                                .amount(MONTHLY_BUDGET_USD)
+                                .unit("USD")
+                                .build())
+                        .build())
+                .notificationsWithSubscribers(List.of(
+                        budgetNotification(alertEmail, "ACTUAL", 80),
+                        budgetNotification(alertEmail, "FORECASTED", 100)))
+                .build();
+    }
+
+    private CfnBudget.NotificationWithSubscribersProperty budgetNotification(
+            String alertEmail, String type, Number threshold) {
+        return CfnBudget.NotificationWithSubscribersProperty.builder()
+                .notification(CfnBudget.NotificationProperty.builder()
+                        .notificationType(type)
+                        .comparisonOperator("GREATER_THAN")
+                        .threshold(threshold)
+                        .thresholdType("PERCENTAGE")
+                        .build())
+                .subscribers(List.of(CfnBudget.SubscriberProperty.builder()
+                        .subscriptionType("EMAIL")
+                        .address(alertEmail)
+                        .build()))
+                .build();
+    }
+
+    private String context(String key, String fallback) {
+        Object value = getNode().tryGetContext(key);
+        return value == null ? fallback : value.toString();
+    }
+
+    private String requiredContext(String key) {
+        Object value = getNode().tryGetContext(key);
+        if (value == null || value.toString().isBlank()) {
+            throw new IllegalStateException(
+                    "Set the " + key + " context value: cdk deploy -c " + key + "=you@example.com");
+        }
+        return value.toString();
+    }
+}

--- a/infra/src/main/java/otto/infra/OttoStack.java
+++ b/infra/src/main/java/otto/infra/OttoStack.java
@@ -119,11 +119,8 @@ public class OttoStack extends Stack {
                 "OTTO_PARAMETER_PATH", parameterPath);
 
         LogGroup scheduledLogs = logGroup("ScheduledLogs");
-        // One scheduled run at a time. Two overlapping runs would read
-        // the same stored documents, and the second would spend a
-        // conflict retry rewriting what the first had just written.
         Function scheduled = appFunction("Scheduled", "otto.aws.ScheduledHandler",
-                SCHEDULED_TIMEOUT, scheduledLogs, environment, 1);
+                SCHEDULED_TIMEOUT, scheduledLogs, environment, scheduledConcurrency());
         Alias scheduledLive = alias("ScheduledLive", scheduled);
 
         LogGroup webhookLogs = logGroup("WebhookLogs");
@@ -167,6 +164,30 @@ public class OttoStack extends Stack {
                 .value(records.getTableName())
                 .description("The small records, one item each")
                 .build();
+    }
+
+    /**
+     * How many scheduled runs may be in flight at once. One is what the
+     * design wants: two overlapping runs read the same stored documents,
+     * and the second spends a conflict retry rewriting what the first
+     * had just written.
+     *
+     * <p>It is a context value rather than a constant because reserving
+     * concurrency spends from an account-wide pool. AWS refuses a
+     * reservation that would leave fewer than 10 unreserved executions,
+     * and a new account is capped at 10 in total - so on a new account
+     * no reservation is possible at all until the quota is raised.
+     *
+     * <p>Pass 0 to reserve nothing. That is not the same as reserving
+     * zero, which would stop the function running; it means the function
+     * draws from the shared pool like any other. The Check is then only
+     * as safe as the storage layer makes it, which is safe but louder:
+     * two overlapping runs both write, and the loser is refused and
+     * retried on the next tick rather than corrupting anything.
+     */
+    private Number scheduledConcurrency() {
+        int reserved = Integer.parseInt(context("scheduledReservedConcurrency", "1"));
+        return reserved > 0 ? reserved : null;
     }
 
     private Bucket documentsBucket() {
@@ -254,11 +275,24 @@ public class OttoStack extends Stack {
                 .effect(Effect.ALLOW)
                 .actions(List.of("ssm:GetParameter", "ssm:GetParameters",
                         "ssm:GetParametersByPath"))
+                // Two ARNs, and both are needed. GetParameter reads one
+                // parameter and is authorized against that parameter, so
+                // it needs the children. GetParametersByPath reads a path
+                // and is authorized against the path itself, which is not
+                // matched by the wildcard over what is under it. Granting
+                // only the children passes every synth assertion and then
+                // fails on the first real call.
+                //
                 // The partition comes from the stack rather than the
-                // literal "aws", so the ARN is built the same way CDK
-                // builds its own and does not assume a commercial region.
-                .resources(List.of("arn:%s:ssm:%s:%s:parameter%s/*"
-                        .formatted(getPartition(), getRegion(), getAccount(), parameterPath)))
+                // literal "aws", so the ARNs are built the way CDK builds
+                // its own and assume no particular partition.
+                .resources(List.of(
+                        "arn:%s:ssm:%s:%s:parameter%s"
+                                .formatted(getPartition(), getRegion(), getAccount(),
+                                        parameterPath),
+                        "arn:%s:ssm:%s:%s:parameter%s/*"
+                                .formatted(getPartition(), getRegion(), getAccount(),
+                                        parameterPath)))
                 .build());
     }
 

--- a/infra/src/test/java/otto/infra/OttoStackTest.java
+++ b/infra/src/test/java/otto/infra/OttoStackTest.java
@@ -1,0 +1,231 @@
+package otto.infra;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import software.amazon.awscdk.App;
+import software.amazon.awscdk.AppProps;
+import software.amazon.awscdk.Environment;
+import software.amazon.awscdk.StackProps;
+import software.amazon.awscdk.assertions.Match;
+import software.amazon.awscdk.assertions.Template;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * What the stack promises, read back off the template it produces. The
+ * assertions are the ticket's acceptance criteria: the shape of the two
+ * functions, the three schedules, the two stores, the alarms, and the
+ * services that are deliberately absent.
+ */
+class OttoStackTest {
+
+    private static Template template;
+
+    @BeforeAll
+    static void synth() {
+        template = Template.fromStack(new OttoStack(app(), "OttoStack", props()));
+    }
+
+    private static App app() {
+        return new App(AppProps.builder()
+                .context(Map.of("alertEmail", "manager@example.com"))
+                .build());
+    }
+
+    private static StackProps props() {
+        return StackProps.builder()
+                .env(Environment.builder().account("111111111111").region("us-east-1").build())
+                .build();
+    }
+
+    @Test
+    void theAppDeploysAsArm64SnapStartLambdas() {
+        template.hasResourceProperties("AWS::Lambda::Function", Map.of(
+                "Handler", "otto.aws.ScheduledHandler",
+                "Runtime", "java25",
+                "Architectures", List.of("arm64"),
+                "MemorySize", 1024,
+                "SnapStart", Map.of("ApplyOn", "PublishedVersions")));
+        template.hasResourceProperties("AWS::Lambda::Function", Map.of(
+                "Handler", "otto.aws.WebhookHandler",
+                "Runtime", "java25",
+                "Architectures", List.of("arm64"),
+                "MemorySize", 1024,
+                "SnapStart", Map.of("ApplyOn", "PublishedVersions")));
+    }
+
+    @Test
+    void theCheckLoopRunsOneAtATime() {
+        template.hasResourceProperties("AWS::Lambda::Function", Map.of(
+                "Handler", "otto.aws.ScheduledHandler",
+                "ReservedConcurrentExecutions", 1));
+    }
+
+    @Test
+    void telegramReachesAFunctionUrlAndNoApiGateway() {
+        template.hasResourceProperties("AWS::Lambda::Url", Map.of("AuthType", "NONE"));
+        template.resourceCountIs("AWS::ApiGateway::RestApi", 0);
+        template.resourceCountIs("AWS::ApiGatewayV2::Api", 0);
+    }
+
+    @Test
+    void theSnapStartVersionsAreWhatTheSchedulesAndTheUrlReach() {
+        // A function URL or a schedule pointed at $LATEST would restore
+        // nothing: SnapStart snapshots published versions.
+        template.resourceCountIs("AWS::Lambda::Alias", 2);
+        template.hasResourceProperties("AWS::Lambda::Alias", Map.of("Name", "live"));
+    }
+
+    @Test
+    void thereAreThreeSchedules() {
+        template.resourceCountIs("AWS::Scheduler::Schedule", 3);
+        template.hasResourceProperties("AWS::Scheduler::Schedule", Map.of(
+                "ScheduleExpression", "rate(1 minute)",
+                "Target", Match.objectLike(Map.of("Input", "{\"job\":\"check\"}"))));
+        template.hasResourceProperties("AWS::Scheduler::Schedule", Map.of(
+                "ScheduleExpression", "rate(1 hour)",
+                "Target", Match.objectLike(Map.of("Input", "{\"job\":\"nflverse-feeds\"}"))));
+        template.hasResourceProperties("AWS::Scheduler::Schedule", Map.of(
+                "ScheduleExpression", "cron(30 3 * * ? *)",
+                "ScheduleExpressionTimezone", "America/Los_Angeles",
+                "Target", Match.objectLike(
+                        Map.of("Input", "{\"job\":\"defense-versus-position\"}"))));
+    }
+
+    @Test
+    void oneBucketHoldsTheBigDocumentsAndOneTableTheSmallRecords() {
+        template.resourceCountIs("AWS::S3::Bucket", 1);
+        template.hasResourceProperties("AWS::S3::Bucket", Match.objectLike(Map.of(
+                "PublicAccessBlockConfiguration", Map.of(
+                        "BlockPublicAcls", true,
+                        "BlockPublicPolicy", true,
+                        "IgnorePublicAcls", true,
+                        "RestrictPublicBuckets", true))));
+
+        template.resourceCountIs("AWS::DynamoDB::Table", 1);
+        template.hasResourceProperties("AWS::DynamoDB::Table", Match.objectLike(Map.of(
+                "BillingMode", "PAY_PER_REQUEST",
+                "KeySchema", List.of(Map.of("AttributeName", "name", "KeyType", "HASH")))));
+    }
+
+    /**
+     * The logical id is what CloudFormation tracks a resource by.
+     * Renaming the construct changes it, and CloudFormation then builds
+     * a new, empty bucket and table and leaves the old ones behind -
+     * the season's Snapshots, Event Log and Settings all still exist,
+     * but the assistant is no longer reading them. `RemovalPolicy.RETAIN`
+     * protects the data from a delete; nothing protects it from a
+     * rename. So the ids are pinned here, and a rename has to be
+     * deliberate enough to update this test.
+     */
+    @Test
+    void theStoresKeepTheirLogicalIdsSoADeployNeverSwapsThemForEmptyOnes() {
+        assertThat(template.findResources("AWS::S3::Bucket").keySet())
+                .containsExactly("Documents7E5B2978");
+        assertThat(template.findResources("AWS::DynamoDB::Table").keySet())
+                .containsExactly("Records091F6ECA");
+    }
+
+    @Test
+    void everyLogGroupKeepsTwoWeeks() {
+        template.allResourcesProperties("AWS::Logs::LogGroup",
+                Match.objectLike(Map.of("RetentionInDays", 14)));
+    }
+
+    @Test
+    void anErrorAndAStoppedCheckLoopBothRaiseAnAlarm() {
+        template.hasResourceProperties("AWS::CloudWatch::Alarm", Match.objectLike(Map.of(
+                "MetricName", "Errors",
+                "ComparisonOperator", "GreaterThanOrEqualToThreshold",
+                "Threshold", 1)));
+        template.hasResourceProperties("AWS::CloudWatch::Alarm", Match.objectLike(Map.of(
+                "MetricName", "CheckCompleted",
+                "ComparisonOperator", "LessThanThreshold",
+                "TreatMissingData", "breaching",
+                "Threshold", 1)));
+    }
+
+    /**
+     * The forwarder is what turns an alarm into a text, so an error in
+     * it would cost every other alarm its voice.
+     */
+    @Test
+    void everyFunctionsLogIsWatchedForErrors() {
+        template.resourceCountIs("AWS::Logs::MetricFilter", 4);
+        template.resourceCountIs("AWS::Logs::LogGroup", 3);
+    }
+
+    @Test
+    void theOneObjectKeepsRecoverableVersionsWithoutKeepingThemForever() {
+        template.hasResourceProperties("AWS::S3::Bucket", Match.objectLike(Map.of(
+                "VersioningConfiguration", Map.of("Status", "Enabled"),
+                "LifecycleConfiguration", Match.objectLike(Map.of(
+                        "Rules", Match.arrayWith(List.of(Match.objectLike(Map.of(
+                                "NoncurrentVersionExpiration",
+                                Map.of("NoncurrentDays", 7))))))))));
+    }
+
+    @Test
+    void anAlarmReachesTheUserByEmailAndByTelegram() {
+        template.hasResourceProperties("AWS::SNS::Subscription",
+                Match.objectLike(Map.of("Protocol", "email",
+                        "Endpoint", "manager@example.com")));
+        template.hasResourceProperties("AWS::SNS::Subscription",
+                Match.objectLike(Map.of("Protocol", "lambda")));
+        template.hasResourceProperties("AWS::Lambda::Function",
+                Match.objectLike(Map.of("Handler", "otto.aws.AlarmForwarderHandler")));
+    }
+
+    @Test
+    void aMonthOfThisIsCappedAtTwentyDollars() {
+        template.hasResourceProperties("AWS::Budgets::Budget", Match.objectLike(Map.of(
+                "Budget", Match.objectLike(Map.of(
+                        "BudgetType", "COST",
+                        "TimeUnit", "MONTHLY",
+                        "BudgetLimit", Map.of("Amount", 20, "Unit", "USD"))))));
+    }
+
+    @Test
+    void theSecretsAreReadFromParameterStoreAndNotFromSecretsManager() {
+        template.resourceCountIs("AWS::SecretsManager::Secret", 0);
+        template.hasResourceProperties("AWS::Lambda::Function", Match.objectLike(Map.of(
+                "Environment", Match.objectLike(Map.of(
+                        "Variables", Match.objectLike(Map.of(
+                                "OTTO_PARAMETER_PATH", "/otto/prod",
+                                "SPRING_PROFILES_ACTIVE", "aws")))))));
+    }
+
+    @Test
+    void theServicesTheSpecRulesOutAreAbsent() {
+        List<String> ruledOut = List.of(
+                "AWS::ApiGateway::RestApi",
+                "AWS::ApiGatewayV2::Api",
+                "AWS::SecretsManager::Secret",
+                "AWS::RDS::DBInstance",
+                "AWS::RDS::DBCluster",
+                "AWS::EC2::VPC",
+                "AWS::ECS::Cluster",
+                "AWS::ECS::Service",
+                "AWS::AppRunner::Service",
+                "AWS::SQS::Queue",
+                "AWS::StepFunctions::StateMachine");
+
+        ruledOut.forEach(type -> template.resourceCountIs(type, 0));
+    }
+
+    @Test
+    void aStackWithNoAlertAddressRefusesToSynthRatherThanDeployDeaf() {
+        assertThatThrownBy(() -> new OttoStack(new App(), "OttoStack", props()))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("alertEmail");
+    }
+
+    @Test
+    void theStackNamesTheWebhookUrlSoTheOperatorCanRegisterIt() {
+        assertThat(template.findOutputs("WebhookUrl")).isNotEmpty();
+    }
+}

--- a/infra/src/test/java/otto/infra/OttoStackTest.java
+++ b/infra/src/test/java/otto/infra/OttoStackTest.java
@@ -1,5 +1,6 @@
 package otto.infra;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -63,6 +64,26 @@ class OttoStackTest {
         template.hasResourceProperties("AWS::Lambda::Function", Map.of(
                 "Handler", "otto.aws.ScheduledHandler",
                 "ReservedConcurrentExecutions", 1));
+    }
+
+    /**
+     * Reserving concurrency spends from an account-wide pool, and AWS
+     * refuses a reservation that leaves fewer than 10 unreserved. A new
+     * account is capped at 10 in total, so it can reserve nothing at
+     * all. The stack has to be able to deploy there.
+     */
+    @Test
+    void anAccountThatCannotSpareTheConcurrencyStillDeploys() {
+        Template unreserved = Template.fromStack(new OttoStack(
+                new App(AppProps.builder()
+                        .context(Map.of("alertEmail", "manager@example.com",
+                                "scheduledReservedConcurrency", "0"))
+                        .build()),
+                "OttoStack", props()));
+
+        unreserved.hasResourceProperties("AWS::Lambda::Function", Match.objectLike(Map.of(
+                "Handler", "otto.aws.ScheduledHandler",
+                "ReservedConcurrentExecutions", Match.absent())));
     }
 
     @Test
@@ -187,6 +208,34 @@ class OttoStackTest {
                         "BudgetType", "COST",
                         "TimeUnit", "MONTHLY",
                         "BudgetLimit", Map.of("Amount", 20, "Unit", "USD"))))));
+    }
+
+    /**
+     * GetParametersByPath is authorized against the path, and
+     * GetParameter against the parameter under it. A grant that names
+     * only the children synthesizes fine and is denied on the first
+     * real call, which is how this was found.
+     */
+    @Test
+    void readingSecretsGrantsBothThePathAndTheParametersUnderIt() {
+        List<Object> grants = new ArrayList<>();
+        for (Map<String, Object> policy : template.findResources("AWS::IAM::Policy").values()) {
+            Map<?, ?> properties = (Map<?, ?>) policy.get("Properties");
+            Map<?, ?> document = (Map<?, ?>) properties.get("PolicyDocument");
+            for (Object entry : (List<?>) document.get("Statement")) {
+                Map<?, ?> statement = (Map<?, ?>) entry;
+                if (String.valueOf(statement.get("Action")).contains("ssm:GetParametersByPath")) {
+                    grants.add(statement.get("Resource"));
+                }
+            }
+        }
+
+        assertThat(grants)
+                .as("one grant each: the scheduled function, the webhook, the forwarder")
+                .hasSize(3)
+                .allSatisfy(resource -> assertThat((List<?>) resource)
+                        .as("the path itself, and the parameters under it")
+                        .hasSize(2));
     }
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,9 @@
     <java.version>25</java.version>
     <spring-ai.version>2.0.0</spring-ai.version>
     <wiremock.version>3.13.1</wiremock.version>
+    <aws-sdk.version>2.51.3</aws-sdk.version>
+    <aws-lambda-core.version>1.4.0</aws-lambda-core.version>
+    <aws-lambda-events.version>3.16.1</aws-lambda-events.version>
   </properties>
 
   <dependencyManagement>
@@ -29,6 +32,13 @@
         <groupId>org.springframework.ai</groupId>
         <artifactId>spring-ai-bom</artifactId>
         <version>${spring-ai.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>software.amazon.awssdk</groupId>
+        <artifactId>bom</artifactId>
+        <version>${aws-sdk.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -57,6 +67,68 @@
       <artifactId>spring-ai-starter-model-openai</artifactId>
     </dependency>
 
+    <!--
+      The AWS side. Each service client drops the Apache and Netty HTTP
+      clients for the JDK-backed one: a Lambda makes a handful of calls
+      per invocation, and a smaller classpath is a shorter init.
+    -->
+    <dependency>
+      <groupId>com.amazonaws</groupId>
+      <artifactId>aws-lambda-java-core</artifactId>
+      <version>${aws-lambda-core.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.amazonaws</groupId>
+      <artifactId>aws-lambda-java-events</artifactId>
+      <version>${aws-lambda-events.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>s3</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>software.amazon.awssdk</groupId>
+          <artifactId>apache-client</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>software.amazon.awssdk</groupId>
+          <artifactId>netty-nio-client</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>dynamodb</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>software.amazon.awssdk</groupId>
+          <artifactId>apache-client</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>software.amazon.awssdk</groupId>
+          <artifactId>netty-nio-client</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>ssm</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>software.amazon.awssdk</groupId>
+          <artifactId>apache-client</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>software.amazon.awssdk</groupId>
+          <artifactId>netty-nio-client</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>url-connection-client</artifactId>
+    </dependency>
+
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
@@ -75,6 +147,33 @@
       <plugin>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
+      </plugin>
+      <!--
+        The Lambda deployable. Lambda's Java runtime reads classes from
+        the zip root and jars from lib/, so the dependencies stay whole:
+        an uber-jar would have to merge every META-INF/spring.factories
+        and spring/*.imports by hand, and a Spring Boot executable jar
+        nests its classes where the runtime cannot see them.
+      -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-assembly-plugin</artifactId>
+        <configuration>
+          <descriptors>
+            <descriptor>src/assembly/lambda.xml</descriptor>
+          </descriptors>
+          <finalName>otto-lambda</finalName>
+          <appendAssemblyId>false</appendAssemblyId>
+        </configuration>
+        <executions>
+          <execution>
+            <id>lambda-zip</id>
+            <phase>package</phase>
+            <goals>
+              <goal>single</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>

--- a/src/assembly/lambda.xml
+++ b/src/assembly/lambda.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<assembly xmlns="http://maven.apache.org/ASSEMBLY/2.2.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.2.0 https://maven.apache.org/xsd/assembly-2.2.0.xsd">
+  <id>lambda</id>
+  <formats>
+    <format>zip</format>
+  </formats>
+  <includeBaseDirectory>false</includeBaseDirectory>
+
+  <fileSets>
+    <fileSet>
+      <directory>${project.build.outputDirectory}</directory>
+      <outputDirectory>/</outputDirectory>
+    </fileSet>
+  </fileSets>
+
+  <dependencySets>
+    <dependencySet>
+      <outputDirectory>lib</outputDirectory>
+      <useProjectArtifact>false</useProjectArtifact>
+      <scope>runtime</scope>
+    </dependencySet>
+  </dependencySets>
+</assembly>

--- a/src/main/java/otto/OttoProperties.java
+++ b/src/main/java/otto/OttoProperties.java
@@ -20,6 +20,7 @@ public record OttoProperties(
         Sleeper sleeper,
         Telegram telegram,
         Nflverse nflverse,
+        Aws aws,
         Duration directoryCheckInterval,
         Duration preDraftCheckInterval,
         Duration sleeperCadence,
@@ -41,5 +42,14 @@ public record OttoProperties(
      */
     public record Nflverse(String apiBaseUrl, String downloadBaseUrl, String playerIdsBaseUrl,
             Duration checkInterval) {
+    }
+
+    /**
+     * Where the deployed assistant keeps its documents. The stack names
+     * the bucket and the table and hands both to the function as
+     * environment variables, so nothing here is checked in. Every field
+     * is null on a laptop, where the local file storage is used instead.
+     */
+    public record Aws(String bucket, String table) {
     }
 }

--- a/src/main/java/otto/aws/AlarmForwarderHandler.java
+++ b/src/main/java/otto/aws/AlarmForwarderHandler.java
@@ -22,6 +22,12 @@ public class AlarmForwarderHandler implements RequestHandler<SNSEvent, String> {
 
     private static final Logger log = LoggerFactory.getLogger(AlarmForwarderHandler.class);
 
+    // No warm-up here, unlike the other two handlers. This function has
+    // no SnapStart, and init without it is limited to 10 seconds, which
+    // is less than a Spring start takes. So the context is built on the
+    // first invocation instead. Alarms are rare and nobody waits on
+    // them, which is the same reason SnapStart was left off.
+
     @Override
     public String handleRequest(SNSEvent event, Context context) {
         TelegramClient telegram = OttoRuntime.bean(TelegramClient.class);

--- a/src/main/java/otto/aws/AlarmForwarderHandler.java
+++ b/src/main/java/otto/aws/AlarmForwarderHandler.java
@@ -1,0 +1,52 @@
+package otto.aws;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestHandler;
+import com.amazonaws.services.lambda.runtime.events.SNSEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import otto.telegram.TelegramClient;
+
+/**
+ * The alarm forwarder: an SNS message about the assistant, sent to the
+ * user's Telegram chat. Email is the durable copy and this is the one
+ * the user reads in time. It is a function of its own because the
+ * thing it reports on is the assistant being broken - a forwarder
+ * inside the assistant would be down with it.
+ *
+ * <p>The wording matches the self-report Alerts, so a broken feed and
+ * a broken function read the same way.
+ */
+public class AlarmForwarderHandler implements RequestHandler<SNSEvent, String> {
+
+    private static final Logger log = LoggerFactory.getLogger(AlarmForwarderHandler.class);
+
+    @Override
+    public String handleRequest(SNSEvent event, Context context) {
+        TelegramClient telegram = OttoRuntime.bean(TelegramClient.class);
+        int sent = 0;
+        for (SNSEvent.SNSRecord record : event.getRecords()) {
+            SNSEvent.SNS message = record.getSNS();
+            if (telegram.sendMessage(text(message))) {
+                sent++;
+            }
+        }
+        log.info("Forwarded {} of {} alarms to Telegram", sent, event.getRecords().size());
+        return "forwarded " + sent;
+    }
+
+    /**
+     * The subject is what CloudWatch put on the alarm, and it is the
+     * part the user needs; the body is the alarm's JSON, which is not.
+     */
+    String text(SNSEvent.SNS message) {
+        String subject = message.getSubject();
+        if (subject == null || subject.isBlank()) {
+            return "Heads up: something in my own plumbing raised an alarm."
+                    + " Check the CloudWatch alarms.";
+        }
+        return "Heads up: %s. I raised that alarm on myself - check the CloudWatch alarms."
+                .formatted(subject);
+    }
+}

--- a/src/main/java/otto/aws/AwsConfig.java
+++ b/src/main/java/otto/aws/AwsConfig.java
@@ -1,0 +1,60 @@
+package otto.aws;
+
+import java.time.Duration;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
+import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.services.s3.S3Client;
+
+import otto.OttoProperties;
+import otto.storage.DocumentBackend;
+
+/**
+ * The wires the deployed assistant has and the laptop does not. The
+ * clients are built at init so a SnapStart restore finds them ready,
+ * and every call is bounded: a Check has one minute before the next
+ * one is due, and a hung AWS call must not eat it.
+ */
+@Configuration
+@Profile("aws")
+public class AwsConfig {
+
+    private static final Duration CALL_TIMEOUT = Duration.ofSeconds(10);
+    private static final Duration ATTEMPT_TIMEOUT = Duration.ofSeconds(5);
+
+    @Bean
+    S3Client s3Client() {
+        return S3Client.builder()
+                .httpClient(UrlConnectionHttpClient.create())
+                .overrideConfiguration(timeouts())
+                .build();
+    }
+
+    @Bean
+    DynamoDbClient dynamoDbClient() {
+        return DynamoDbClient.builder()
+                .httpClient(UrlConnectionHttpClient.create())
+                .overrideConfiguration(timeouts())
+                .build();
+    }
+
+    @Bean
+    DocumentBackend awsDocumentBackend(S3Client s3, DynamoDbClient dynamo,
+            OttoProperties properties) {
+        OttoProperties.Aws aws = properties.aws();
+        return new AwsDocumentBackend(
+                new S3BundleBackend(s3, aws.bucket()),
+                new DynamoDbBackend(dynamo, aws.table()));
+    }
+
+    private ClientOverrideConfiguration timeouts() {
+        return ClientOverrideConfiguration.builder()
+                .apiCallTimeout(CALL_TIMEOUT)
+                .apiCallAttemptTimeout(ATTEMPT_TIMEOUT)
+                .build();
+    }
+}

--- a/src/main/java/otto/aws/AwsDocumentBackend.java
+++ b/src/main/java/otto/aws/AwsDocumentBackend.java
@@ -1,0 +1,40 @@
+package otto.aws;
+
+import java.util.Optional;
+
+import otto.storage.DocumentBackend;
+
+/**
+ * The deployed assistant's storage: every document goes to S3 or to
+ * DynamoDB by what {@link DocumentPlacement} says about its name.
+ */
+public class AwsDocumentBackend implements DocumentBackend {
+
+    private final DocumentBackend big;
+    private final DocumentBackend small;
+
+    public AwsDocumentBackend(DocumentBackend big, DocumentBackend small) {
+        this.big = big;
+        this.small = small;
+    }
+
+    @Override
+    public Optional<byte[]> load(String name) {
+        return backendFor(name).load(name);
+    }
+
+    @Override
+    public void store(String name, byte[] json) {
+        backendFor(name).store(name, json);
+    }
+
+    @Override
+    public void flush() {
+        big.flush();
+        small.flush();
+    }
+
+    private DocumentBackend backendFor(String name) {
+        return DocumentPlacement.isBig(name) ? big : small;
+    }
+}

--- a/src/main/java/otto/aws/DocumentPlacement.java
+++ b/src/main/java/otto/aws/DocumentPlacement.java
@@ -1,0 +1,43 @@
+package otto.aws;
+
+import java.util.Set;
+
+/**
+ * Which store a document belongs in. The spec splits storage two ways:
+ * big documents go to S3, small records go to DynamoDB.
+ *
+ * <p>Small is the named list, and everything else is big. That way
+ * round rather than the other because of what each mistake costs. A
+ * new document that should have been small and goes to S3 costs a slot
+ * in the bundle and nothing else. A new document that should have been
+ * big and goes to DynamoDB works until the season makes it pass the
+ * 400 KB item limit, which is the middle of a season and not a
+ * deployment. So a document nobody has thought about lands in the
+ * store that cannot be outgrown.
+ *
+ * <p>Small means a record whose size is settled by its shape: the
+ * user's Settings, Watchlist and Mutes, one conversation trimmed to
+ * its newest turns, and three markers. Big means everything that grows
+ * with the league, the roster of players or the season - the
+ * Snapshots, the Player Directory, the nflverse feeds,
+ * defense-versus-position and the Event Log.
+ */
+public final class DocumentPlacement {
+
+    private static final Set<String> SMALL = Set.of(
+            "settings",
+            "watchlist",
+            "watchlist-observations",
+            "mutes",
+            "conversation",
+            "last-check",
+            "alert-id-sequence",
+            "telegram-updates");
+
+    private DocumentPlacement() {
+    }
+
+    public static boolean isBig(String name) {
+        return !SMALL.contains(name);
+    }
+}

--- a/src/main/java/otto/aws/DynamoDbBackend.java
+++ b/src/main/java/otto/aws/DynamoDbBackend.java
@@ -1,0 +1,64 @@
+package otto.aws;
+
+import java.util.Map;
+import java.util.Optional;
+
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.GetItemRequest;
+import software.amazon.awssdk.services.dynamodb.model.PutItemRequest;
+
+import otto.storage.DocumentBackend;
+
+/**
+ * The small records: Settings, the Watchlist, Mutes, the conversation,
+ * the last Check and the Alert id sequence, one item each. Reads are
+ * strongly consistent, because the webhook writes what the next Check
+ * reads a moment later and an eventually consistent read could answer
+ * with the record the user just changed away from.
+ *
+ * <p>Writes go straight through. These records are small and few, so
+ * batching them would buy nothing and would cost the guarantee that a
+ * stored Alert id is stored before the Alert goes out.
+ */
+public class DynamoDbBackend implements DocumentBackend {
+
+    /** The partition key: the document name the caller asked for. */
+    static final String NAME = "name";
+
+    /** The document itself, held as bytes so no JSON is reshaped in transit. */
+    static final String DOCUMENT = "document";
+
+    private final DynamoDbClient dynamo;
+    private final String table;
+
+    public DynamoDbBackend(DynamoDbClient dynamo, String table) {
+        this.dynamo = dynamo;
+        this.table = table;
+    }
+
+    @Override
+    public Optional<byte[]> load(String name) {
+        Map<String, AttributeValue> item = dynamo.getItem(GetItemRequest.builder()
+                .tableName(table)
+                .key(Map.of(NAME, AttributeValue.fromS(name)))
+                .consistentRead(true)
+                .build()).item();
+        if (item == null || item.isEmpty()) {
+            return Optional.empty();
+        }
+        return Optional.of(item.get(DOCUMENT).b().asByteArray());
+    }
+
+    @Override
+    public void store(String name, byte[] json) {
+        dynamo.putItem(PutItemRequest.builder()
+                .tableName(table)
+                .item(Map.of(
+                        NAME, AttributeValue.fromS(name),
+                        DOCUMENT, AttributeValue.fromB(SdkBytes.fromByteArray(json))))
+                .build());
+    }
+
+}

--- a/src/main/java/otto/aws/OttoRuntime.java
+++ b/src/main/java/otto/aws/OttoRuntime.java
@@ -1,5 +1,7 @@
 package otto.aws;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.boot.WebApplicationType;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.context.ConfigurableApplicationContext;
@@ -14,10 +16,32 @@ import otto.OttoApplication;
  *
  * <p>Every handler reads its beans from here. One context per
  * container serves however many invocations that container sees.
+ *
+ * <p>A start that fails is caught rather than thrown. That looks
+ * over-careful and is not. Java marks a class whose static
+ * initializer threw as erroneous for the life of the JVM, and every
+ * later use of it fails with NoClassDefFoundError rather than with the
+ * original cause. Under SnapStart that dead JVM is what gets
+ * snapshotted, and every environment restored from it starts broken -
+ * so a missing permission at publish time would outlive the fix for
+ * it, and only a new function version could clear it. Catching here
+ * keeps the class usable, so the next invocation tries again and the
+ * assistant recovers on its own once the cause is gone.
  */
 public final class OttoRuntime {
 
-    private static final ConfigurableApplicationContext CONTEXT = start();
+    private static final Logger log = LoggerFactory.getLogger(OttoRuntime.class);
+
+    private static volatile ConfigurableApplicationContext context;
+
+    static {
+        try {
+            context = start();
+        } catch (RuntimeException e) {
+            log.error("The assistant did not start during init; the next invocation"
+                    + " will try again", e);
+        }
+    }
 
     private OttoRuntime() {
     }
@@ -30,6 +54,24 @@ public final class OttoRuntime {
     }
 
     public static <T> T bean(Class<T> type) {
-        return CONTEXT.getBean(type);
+        return started().getBean(type);
+    }
+
+    /**
+     * The context, started on the first invocation that needs it if
+     * init could not start it. The happy path never reaches the
+     * synchronized method: it is the field read above.
+     */
+    private static ConfigurableApplicationContext started() {
+        ConfigurableApplicationContext running = context;
+        return running != null ? running : startNow();
+    }
+
+    private static synchronized ConfigurableApplicationContext startNow() {
+        if (context == null) {
+            log.warn("Starting the assistant now, having failed to start during init");
+            context = start();
+        }
+        return context;
     }
 }

--- a/src/main/java/otto/aws/OttoRuntime.java
+++ b/src/main/java/otto/aws/OttoRuntime.java
@@ -1,0 +1,35 @@
+package otto.aws;
+
+import org.springframework.boot.WebApplicationType;
+import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.context.ConfigurableApplicationContext;
+
+import otto.OttoApplication;
+
+/**
+ * The one Spring context the deployed assistant runs in. It is built
+ * while the class loads, which is Lambda's init phase, so SnapStart
+ * takes its snapshot with the context already up: a restored function
+ * answers without paying for a Spring start.
+ *
+ * <p>Every handler reads its beans from here. One context per
+ * container serves however many invocations that container sees.
+ */
+public final class OttoRuntime {
+
+    private static final ConfigurableApplicationContext CONTEXT = start();
+
+    private OttoRuntime() {
+    }
+
+    private static ConfigurableApplicationContext start() {
+        return new SpringApplicationBuilder(OttoApplication.class)
+                .web(WebApplicationType.NONE)
+                .profiles("aws")
+                .run();
+    }
+
+    public static <T> T bean(Class<T> type) {
+        return CONTEXT.getBean(type);
+    }
+}

--- a/src/main/java/otto/aws/OttoRuntime.java
+++ b/src/main/java/otto/aws/OttoRuntime.java
@@ -34,16 +34,32 @@ public final class OttoRuntime {
 
     private static volatile ConfigurableApplicationContext context;
 
-    static {
-        try {
-            context = start();
-        } catch (RuntimeException e) {
-            log.error("The assistant did not start during init; the next invocation"
-                    + " will try again", e);
-        }
+    private OttoRuntime() {
     }
 
-    private OttoRuntime() {
+    /**
+     * Builds the context now, and never throws.
+     *
+     * <p>A handler on SnapStart calls this from its constructor,
+     * because that is what puts a started application inside the
+     * snapshot. Doing it in a static initializer here does not: Java
+     * initializes a class on first active use, and nothing uses this
+     * one until a handler asks for a bean - which is the first
+     * invocation, long after the snapshot was taken. The context would
+     * then be built while the user waited, once per execution
+     * environment, and SnapStart would restore an application that had
+     * never started.
+     *
+     * <p>A handler without SnapStart must not call this. Init is
+     * limited to 10 seconds there, and Spring takes longer than that.
+     */
+    public static void warmUp() {
+        try {
+            started();
+        } catch (RuntimeException e) {
+            log.error("The assistant did not start during init; the first invocation"
+                    + " will try again", e);
+        }
     }
 
     private static ConfigurableApplicationContext start() {
@@ -58,9 +74,9 @@ public final class OttoRuntime {
     }
 
     /**
-     * The context, started on the first invocation that needs it if
-     * init could not start it. The happy path never reaches the
-     * synchronized method: it is the field read above.
+     * The context, built on the first call that needs it. Once it is
+     * up, every later call is the plain field read here rather than
+     * the synchronized method.
      */
     private static ConfigurableApplicationContext started() {
         ConfigurableApplicationContext running = context;
@@ -69,7 +85,6 @@ public final class OttoRuntime {
 
     private static synchronized ConfigurableApplicationContext startNow() {
         if (context == null) {
-            log.warn("Starting the assistant now, having failed to start during init");
             context = start();
         }
         return context;

--- a/src/main/java/otto/aws/S3BundleBackend.java
+++ b/src/main/java/otto/aws/S3BundleBackend.java
@@ -1,0 +1,244 @@
+package otto.aws;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.MissingNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.awscore.exception.AwsServiceException;
+import software.amazon.awssdk.core.ResponseBytes;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
+import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectResponse;
+
+import otto.storage.DocumentBackend;
+import otto.storage.OttoJson;
+
+/**
+ * The big documents, held as one S3 object. A run reads the object
+ * once and writes it once: a Check touches the Snapshot, the Event Log
+ * and the feeds, and one object write a minute costs one round trip
+ * rather than one per document.
+ *
+ * <p>Two entry points write - the Check and the webhook both append to
+ * the Event Log - so the write carries the ETag the run read. S3
+ * refuses a write whose ETag no longer matches, and the backend then
+ * re-reads and reapplies this run's documents on top of what the other
+ * writer stored. Without that, the later of two overlapping writes
+ * would silently drop the earlier one's work.
+ *
+ * <p>Reapplying is only safe for a document the other writer left
+ * alone. Where both runs changed the same document, this run's value
+ * was derived from a version that no longer exists - a Check that read
+ * the Event Log, appended to it, and then met the webhook's own append
+ * would overwrite the user's tap. There is no general way to merge two
+ * documents here, so that case is refused loudly rather than resolved
+ * quietly: the Check errors, the error alarm sees it, and the next
+ * minute's run reads the Event Log the tap is now in.
+ */
+public class S3BundleBackend implements DocumentBackend {
+
+    private static final Logger log = LoggerFactory.getLogger(S3BundleBackend.class);
+
+    /** The one object every big document lives in. */
+    static final String KEY = "documents.json";
+
+    /** How many times a refused write re-reads and tries again. */
+    private static final int WRITE_ATTEMPTS = 3;
+
+    private final S3Client s3;
+    private final String bucket;
+
+    /** This run's documents, waiting for the flush that stores them. */
+    private final Map<String, JsonNode> pending = new LinkedHashMap<>();
+
+    /**
+     * What each of this run's documents held when the run first touched
+     * it. A conflict is only resolvable where this still matches what
+     * S3 holds - that is what says the other writer left this document
+     * alone. Missing means the document did not exist yet.
+     */
+    private final Map<String, JsonNode> base = new LinkedHashMap<>();
+
+    private ObjectNode bundle;
+    private String etag;
+
+    /** True when the held bundle may be behind what S3 now holds. */
+    private boolean stale = true;
+
+    public S3BundleBackend(S3Client s3, String bucket) {
+        this.s3 = s3;
+        this.bucket = bucket;
+    }
+
+    @Override
+    public synchronized Optional<byte[]> load(String name) {
+        JsonNode written = pending.get(name);
+        if (written != null) {
+            return Optional.of(bytes(written));
+        }
+        JsonNode stored = loaded().get(name);
+        return stored == null ? Optional.empty() : Optional.of(bytes(stored));
+    }
+
+    @Override
+    public synchronized void store(String name, byte[] json) {
+        base.putIfAbsent(name, held(loaded(), name));
+        pending.put(name, parse(name, json));
+    }
+
+    /**
+     * Stores this run's documents in one write. The bundle is marked
+     * stale either way, so the next run re-reads it: the other entry
+     * point may have written between the two, and a conditional read
+     * costs nothing when it has not.
+     */
+    @Override
+    public synchronized void flush() {
+        try {
+            if (!pending.isEmpty()) {
+                writePending();
+            }
+        } finally {
+            // Cleared even when the write failed. The run is over either
+            // way, and holding its documents would apply them to a later
+            // run that has since read newer ones.
+            pending.clear();
+            base.clear();
+            stale = true;
+        }
+    }
+
+    private void writePending() {
+        for (int attempt = 1; attempt <= WRITE_ATTEMPTS; attempt++) {
+            ObjectNode merged = loaded().deepCopy();
+            pending.forEach(merged::set);
+            try {
+                put(merged);
+                return;
+            } catch (AwsServiceException e) {
+                if (e.statusCode() != 412 || attempt == WRITE_ATTEMPTS) {
+                    throw e;
+                }
+                log.info("The stored documents moved under this run; re-reading and"
+                        + " applying this run's documents again (attempt {})", attempt);
+                stale = true;
+                refuseWhereTheOtherWriterTouchedTheSameDocument();
+            }
+        }
+    }
+
+    /**
+     * Reapplying this run's documents is safe only where the other
+     * writer changed none of them. Where it changed one this run also
+     * changed, this run's value came from a version that is gone, and
+     * writing it would drop the other writer's work.
+     */
+    private void refuseWhereTheOtherWriterTouchedTheSameDocument() {
+        ObjectNode stored = loaded();
+        for (String name : pending.keySet()) {
+            if (!base.get(name).equals(held(stored, name))) {
+                throw new ConcurrentDocumentChange(name);
+            }
+        }
+    }
+
+    /** What the bundle holds for a name, or a missing node when nothing. */
+    private JsonNode held(ObjectNode bundle, String name) {
+        JsonNode stored = bundle.get(name);
+        return stored == null ? MissingNode.getInstance() : stored;
+    }
+
+    /** Raised when two runs changed one document and neither may win. */
+    public static class ConcurrentDocumentChange extends IllegalStateException {
+
+        ConcurrentDocumentChange(String name) {
+            super("The other entry point changed " + name + " while this run held it."
+                    + " This run's copy is dropped rather than written over it.");
+        }
+    }
+
+    private void put(ObjectNode merged) {
+        PutObjectRequest.Builder request = PutObjectRequest.builder()
+                .bucket(bucket)
+                .key(KEY)
+                .contentType("application/json");
+        if (etag == null) {
+            // No object yet: the write must lose to whoever creates it first.
+            request.ifNoneMatch("*");
+        } else {
+            request.ifMatch(etag);
+        }
+        PutObjectResponse response = s3.putObject(request.build(),
+                RequestBody.fromBytes(bytes(merged)));
+        bundle = merged;
+        etag = response.eTag();
+    }
+
+    /**
+     * The bundle S3 holds. A stale bundle is re-read conditionally, so
+     * a run that finds nothing changed pays for a 304 and no body.
+     */
+    private ObjectNode loaded() {
+        if (bundle != null && !stale) {
+            return bundle;
+        }
+        try {
+            GetObjectRequest.Builder request = GetObjectRequest.builder()
+                    .bucket(bucket)
+                    .key(KEY);
+            if (etag != null) {
+                request.ifNoneMatch(etag);
+            }
+            ResponseBytes<GetObjectResponse> object =
+                    s3.getObjectAsBytes(request.build());
+            bundle = read(object.asByteArray());
+            etag = object.response().eTag();
+        } catch (NoSuchKeyException e) {
+            bundle = OttoJson.MAPPER.createObjectNode();
+            etag = null;
+        } catch (AwsServiceException e) {
+            if (e.statusCode() != 304) {
+                throw e;
+            }
+        }
+        stale = false;
+        return bundle;
+    }
+
+    private ObjectNode read(byte[] json) {
+        try {
+            JsonNode parsed = OttoJson.MAPPER.readTree(json);
+            if (parsed instanceof ObjectNode object) {
+                return object;
+            }
+            throw new IllegalStateException(
+                    "The stored documents object is not a JSON object: " + KEY);
+        } catch (IOException e) {
+            throw new UncheckedIOException("Cannot read the stored documents object", e);
+        }
+    }
+
+    private JsonNode parse(String name, byte[] json) {
+        try {
+            return OttoJson.MAPPER.readTree(json);
+        } catch (IOException e) {
+            throw new UncheckedIOException("Cannot hold document " + name, e);
+        }
+    }
+
+    private byte[] bytes(JsonNode node) {
+        return node.toString().getBytes(StandardCharsets.UTF_8);
+    }
+}

--- a/src/main/java/otto/aws/S3BundleBackend.java
+++ b/src/main/java/otto/aws/S3BundleBackend.java
@@ -22,6 +22,7 @@ import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectResponse;
 
+import otto.storage.ConcurrentDocumentChange;
 import otto.storage.DocumentBackend;
 import otto.storage.OttoJson;
 
@@ -160,14 +161,6 @@ public class S3BundleBackend implements DocumentBackend {
         return stored == null ? MissingNode.getInstance() : stored;
     }
 
-    /** Raised when two runs changed one document and neither may win. */
-    public static class ConcurrentDocumentChange extends IllegalStateException {
-
-        ConcurrentDocumentChange(String name) {
-            super("The other entry point changed " + name + " while this run held it."
-                    + " This run's copy is dropped rather than written over it.");
-        }
-    }
 
     private void put(ObjectNode merged) {
         PutObjectRequest.Builder request = PutObjectRequest.builder()

--- a/src/main/java/otto/aws/ScheduledHandler.java
+++ b/src/main/java/otto/aws/ScheduledHandler.java
@@ -39,6 +39,16 @@ public class ScheduledHandler implements RequestHandler<Map<String, Object>, Str
      */
     static final String HEARTBEAT = "heartbeat check-completed";
 
+    /**
+     * Lambda constructs the handler during the init phase, so this is
+     * what puts a started application inside the SnapStart snapshot.
+     * Without it the context would be built during the first
+     * invocation of every execution environment instead.
+     */
+    public ScheduledHandler() {
+        OttoRuntime.warmUp();
+    }
+
     @Override
     public String handleRequest(Map<String, Object> event, Context context) {
         String job = String.valueOf(event.getOrDefault(JOB, ScheduledJob.CHECK.jobName()));

--- a/src/main/java/otto/aws/ScheduledHandler.java
+++ b/src/main/java/otto/aws/ScheduledHandler.java
@@ -1,0 +1,75 @@
+package otto.aws;
+
+import java.util.Map;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestHandler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import otto.check.CheckResult;
+import otto.check.CheckRunner;
+import otto.nflverse.DefenseVersusPositionBuilder;
+import otto.nflverse.NflverseFeedService;
+import otto.storage.JsonStore;
+
+/**
+ * The scheduled entry point. Three EventBridge schedules reach it and
+ * name the job they want: the 1-minute Check, the hourly nflverse
+ * timestamp check, and the nightly defense-versus-position build. The
+ * Lock Ladder, the Tuesday waiver Alert and the 20-minute Done
+ * follow-up need no schedule of their own - they ride the 1-minute
+ * loop and the Event Log.
+ *
+ * <p>One function serves all three, so one warm context serves all
+ * three. Every run flushes the storage batch, whether or not it
+ * finished, so a run that half succeeded still keeps what it learned.
+ */
+public class ScheduledHandler implements RequestHandler<Map<String, Object>, String> {
+
+    private static final Logger log = LoggerFactory.getLogger(ScheduledHandler.class);
+
+    /** The field an EventBridge schedule sets to pick its job. */
+    static final String JOB = "job";
+
+    /**
+     * The line the heartbeat alarm counts. A Check that ran is a Check
+     * loop that is alive, whether or not the pre-draft cadence let it
+     * do any work, so the marker sits outside that branch.
+     */
+    static final String HEARTBEAT = "heartbeat check-completed";
+
+    @Override
+    public String handleRequest(Map<String, Object> event, Context context) {
+        String job = String.valueOf(event.getOrDefault(JOB, ScheduledJob.CHECK.jobName()));
+        ScheduledJob scheduled = ScheduledJob.of(job);
+        return StoredRun.storing(OttoRuntime.bean(JsonStore.class), () -> run(scheduled));
+    }
+
+    private String run(ScheduledJob job) {
+        return switch (job) {
+            case CHECK -> check();
+            case NFLVERSE_FEEDS -> nflverseFeeds();
+            case DEFENSE_VERSUS_POSITION -> defenseVersusPosition();
+        };
+    }
+
+    private String check() {
+        CheckResult result = OttoRuntime.bean(CheckRunner.class).runCheck();
+        log.info(HEARTBEAT);
+        if (result.skipped()) {
+            return "Check skipped by pre-draft cadence";
+        }
+        return "Check done: %d new events, %d alerts sent"
+                .formatted(result.newEvents().size(), result.alertsSent().size());
+    }
+
+    private String nflverseFeeds() {
+        return "nflverse feeds: " + OttoRuntime.bean(NflverseFeedService.class).updateIfDue();
+    }
+
+    private String defenseVersusPosition() {
+        OttoRuntime.bean(DefenseVersusPositionBuilder.class).build();
+        return "defense-versus-position built";
+    }
+}

--- a/src/main/java/otto/aws/ScheduledJob.java
+++ b/src/main/java/otto/aws/ScheduledJob.java
@@ -1,0 +1,45 @@
+package otto.aws;
+
+import java.util.Arrays;
+
+/**
+ * The three scheduled jobs, named the way an EventBridge schedule
+ * names them.
+ *
+ * <p>The stack spells the same names in its schedule payloads and
+ * cannot import them: the deployable must not carry the CDK libraries,
+ * so the two builds are separate. Each side pins its own spelling in a
+ * test - {@code OttoStackTest.thereAreThreeSchedules} for the payloads,
+ * {@code AwsEntryPointScenarioTest.everyScheduleNamesAJobTheBuildHas}
+ * for these - so a rename that reaches only one side fails a build
+ * rather than a schedule.
+ */
+public enum ScheduledJob {
+
+    CHECK("check"),
+    NFLVERSE_FEEDS("nflverse-feeds"),
+    DEFENSE_VERSUS_POSITION("defense-versus-position");
+
+    private final String jobName;
+
+    ScheduledJob(String jobName) {
+        this.jobName = jobName;
+    }
+
+    public String jobName() {
+        return jobName;
+    }
+
+    /**
+     * An unknown job is refused rather than run as a Check. A schedule
+     * that names a job this build does not have is a deployment
+     * mistake, and running the wrong job would hide it.
+     */
+    public static ScheduledJob of(String jobName) {
+        return Arrays.stream(values())
+                .filter(job -> job.jobName.equals(jobName))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException(
+                        "No such scheduled job: " + jobName));
+    }
+}

--- a/src/main/java/otto/aws/SsmSecrets.java
+++ b/src/main/java/otto/aws/SsmSecrets.java
@@ -1,0 +1,96 @@
+package otto.aws;
+
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.EnvironmentPostProcessor;
+import org.springframework.boot.SpringApplication;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.MapPropertySource;
+import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
+import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient;
+import software.amazon.awssdk.services.ssm.SsmClient;
+import software.amazon.awssdk.services.ssm.model.GetParametersByPathRequest;
+import software.amazon.awssdk.services.ssm.model.Parameter;
+
+/**
+ * The secrets, read from SSM Parameter Store once at init. The bot
+ * token, the chat id, the webhook secret and the model key are
+ * SecureStrings under one path; a parameter's leaf name is the
+ * property it sets, so adding a secret needs no code.
+ *
+ * <p>Reading them here, before the context is built, is what makes
+ * them free at request time: the values are in the environment the
+ * beans are configured from, and under SnapStart they are inside the
+ * restored snapshot. The cost of that is the point of the design -
+ * rotating a secret needs a new function version, not just a new
+ * parameter value.
+ *
+ * <p>The trigger is the path, not the profile. Profiles are settled
+ * later than this runs, and a missing secret would be found only when
+ * a message failed to send.
+ */
+public class SsmSecrets implements EnvironmentPostProcessor {
+
+    private static final Logger log = LoggerFactory.getLogger(SsmSecrets.class);
+
+    /** The environment variable the stack sets to the parameter path. */
+    static final String PATH_VARIABLE = "OTTO_PARAMETER_PATH";
+
+    static final String SOURCE_NAME = "otto-ssm-parameters";
+
+    private static final Duration CALL_TIMEOUT = Duration.ofSeconds(10);
+
+    @Override
+    public void postProcessEnvironment(ConfigurableEnvironment environment,
+            SpringApplication application) {
+        String path = environment.getProperty(PATH_VARIABLE);
+        if (path == null || path.isBlank()) {
+            return;
+        }
+        Map<String, Object> properties = read(path);
+        // First, so a secret beats the placeholder default in application.yml.
+        environment.getPropertySources()
+                .addFirst(new MapPropertySource(SOURCE_NAME, properties));
+        log.info("Read {} secrets from SSM under {}", properties.size(), path);
+    }
+
+    private Map<String, Object> read(String path) {
+        Map<String, Object> properties = new HashMap<>();
+        try (SsmClient ssm = client()) {
+            ssm.getParametersByPathPaginator(GetParametersByPathRequest.builder()
+                            .path(path)
+                            .recursive(true)
+                            .withDecryption(true)
+                            .build())
+                    .stream()
+                    .flatMap(page -> page.parameters().stream())
+                    .forEach(parameter -> properties.put(propertyName(parameter),
+                            parameter.value()));
+        }
+        return properties;
+    }
+
+    /** The leaf of "/otto/prod/otto.telegram.bot-token" is the property it sets. */
+    private String propertyName(Parameter parameter) {
+        String name = parameter.name();
+        return name.substring(name.lastIndexOf('/') + 1);
+    }
+
+    /**
+     * A client of its own, closed once the secrets are read. The
+     * context is not built yet, so there is no bean to borrow, and
+     * nothing after init reads a parameter.
+     */
+    private SsmClient client() {
+        return SsmClient.builder()
+                .httpClient(UrlConnectionHttpClient.create())
+                .overrideConfiguration(ClientOverrideConfiguration.builder()
+                        .apiCallTimeout(CALL_TIMEOUT)
+                        .build())
+                .build();
+    }
+}

--- a/src/main/java/otto/aws/StoredRun.java
+++ b/src/main/java/otto/aws/StoredRun.java
@@ -1,0 +1,34 @@
+package otto.aws;
+
+import java.util.function.Supplier;
+
+import otto.storage.JsonStore;
+
+/**
+ * One invocation's work, and the store call that keeps what it learned.
+ * A run that failed part way still stores - a Check that read the
+ * Snapshot and then lost a feed has learned the Snapshot. A store that
+ * fails as well never hides why the run failed: it is attached to the
+ * first failure rather than thrown over it.
+ */
+final class StoredRun {
+
+    private StoredRun() {
+    }
+
+    static <T> T storing(JsonStore store, Supplier<T> work) {
+        T outcome;
+        try {
+            outcome = work.get();
+        } catch (RuntimeException failure) {
+            try {
+                store.flush();
+            } catch (RuntimeException alsoFailed) {
+                failure.addSuppressed(alsoFailed);
+            }
+            throw failure;
+        }
+        store.flush();
+        return outcome;
+    }
+}

--- a/src/main/java/otto/aws/WebhookHandler.java
+++ b/src/main/java/otto/aws/WebhookHandler.java
@@ -1,0 +1,88 @@
+package otto.aws;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestHandler;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayV2HTTPEvent;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayV2HTTPResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import otto.storage.JsonStore;
+import otto.telegram.TelegramWebhook;
+import otto.telegram.WebhookResult;
+
+/**
+ * The Telegram entry point: a Lambda function URL, which speaks the
+ * same payload as an HTTP API and needs no API Gateway in front of it.
+ * The handler unwraps the request and hands the secret token and the
+ * body to {@link TelegramWebhook}, the seam the local long poll also
+ * calls, so the deployed front door adds no behavior of its own.
+ */
+public class WebhookHandler
+        implements RequestHandler<APIGatewayV2HTTPEvent, APIGatewayV2HTTPResponse> {
+
+    private static final Logger log = LoggerFactory.getLogger(WebhookHandler.class);
+
+    /** The header Telegram echoes the registered secret in. */
+    static final String SECRET_HEADER = "x-telegram-bot-api-secret-token";
+
+    @Override
+    public APIGatewayV2HTTPResponse handleRequest(APIGatewayV2HTTPEvent request,
+            Context context) {
+        try {
+            return StoredRun.storing(OttoRuntime.bean(JsonStore.class), () -> {
+                WebhookResult result = OttoRuntime.bean(TelegramWebhook.class)
+                        .handle(secretToken(request).orElse(null), body(request));
+                return answer(result == WebhookResult.OK ? 200 : 403);
+            });
+        } catch (RuntimeException e) {
+            // Telegram retries what it is not told was taken, and a retry
+            // of a body that broke us would break us again. The failure is
+            // logged for the error alarm and the update is let go.
+            log.error("Webhook update dropped: {}", e.getClass().getSimpleName(), e);
+            return answer(200);
+        }
+    }
+
+    /**
+     * Header names arrive lowercased on a function URL, but the lookup
+     * does not depend on that: a header this one call turns on is worth
+     * no assumption about the runtime's spelling.
+     */
+    Optional<String> secretToken(APIGatewayV2HTTPEvent request) {
+        Map<String, String> headers = request.getHeaders();
+        if (headers == null) {
+            return Optional.empty();
+        }
+        return headers.entrySet().stream()
+                .filter(header -> header.getKey() != null
+                        && header.getKey().toLowerCase(Locale.ROOT).equals(SECRET_HEADER))
+                .map(Map.Entry::getValue)
+                .findFirst();
+    }
+
+    /** Lambda base64-encodes a body it does not read as text. */
+    String body(APIGatewayV2HTTPEvent request) {
+        String body = request.getBody();
+        if (body == null) {
+            return "";
+        }
+        if (!request.getIsBase64Encoded()) {
+            return body;
+        }
+        return new String(Base64.getDecoder().decode(body), StandardCharsets.UTF_8);
+    }
+
+    private APIGatewayV2HTTPResponse answer(int statusCode) {
+        return APIGatewayV2HTTPResponse.builder()
+                .withStatusCode(statusCode)
+                .withBody("")
+                .build();
+    }
+}

--- a/src/main/java/otto/aws/WebhookHandler.java
+++ b/src/main/java/otto/aws/WebhookHandler.java
@@ -13,6 +13,7 @@ import com.amazonaws.services.lambda.runtime.events.APIGatewayV2HTTPResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import otto.storage.ConcurrentDocumentChange;
 import otto.storage.JsonStore;
 import otto.telegram.TelegramWebhook;
 import otto.telegram.WebhookResult;
@@ -41,13 +42,36 @@ public class WebhookHandler
                         .handle(secretToken(request).orElse(null), body(request));
                 return answer(result == WebhookResult.OK ? 200 : 403);
             });
-        } catch (RuntimeException e) {
-            // Telegram retries what it is not told was taken, and a retry
-            // of a body that broke us would break us again. The failure is
-            // logged for the error alarm and the update is let go.
-            log.error("Webhook update dropped: {}", e.getClass().getSimpleName(), e);
-            return answer(200);
+        } catch (RuntimeException failure) {
+            return recoverFrom(failure);
         }
+    }
+
+    /**
+     * What to tell Telegram when the update did not go through. The two
+     * cases pull in opposite directions, so they are answered
+     * differently.
+     *
+     * <p>A run whose storage was refused lost the user's tap, and the
+     * user has already been told it worked - the acknowledgement goes
+     * out while the update is handled, before the run stores anything.
+     * Nothing else will ever retry it. So Telegram is asked to send it
+     * again, which it does for any answer that is not a success. A
+     * resent tap costs nothing: the Event Log keys on the event id, so
+     * applying the same tap twice appends once.
+     *
+     * <p>Anything else is a body this build cannot handle. Asking for
+     * that again would fail again, on a loop, so it is logged for the
+     * error alarm and let go.
+     */
+    APIGatewayV2HTTPResponse recoverFrom(RuntimeException failure) {
+        if (failure instanceof ConcurrentDocumentChange) {
+            log.warn("Webhook update left for Telegram to send again: {}",
+                    failure.getMessage());
+            return answer(503);
+        }
+        log.error("Webhook update dropped: {}", failure.getClass().getSimpleName(), failure);
+        return answer(200);
     }
 
     /**

--- a/src/main/java/otto/aws/WebhookHandler.java
+++ b/src/main/java/otto/aws/WebhookHandler.java
@@ -33,6 +33,17 @@ public class WebhookHandler
     /** The header Telegram echoes the registered secret in. */
     static final String SECRET_HEADER = "x-telegram-bot-api-secret-token";
 
+    /**
+     * Lambda constructs the handler during the init phase, so this is
+     * what puts a started application inside the SnapStart snapshot.
+     * It matters most here: the user is waiting for the reply, and the
+     * webhook is idle between messages, so nearly every message would
+     * otherwise arrive at an environment that had yet to start Spring.
+     */
+    public WebhookHandler() {
+        OttoRuntime.warmUp();
+    }
+
     @Override
     public APIGatewayV2HTTPResponse handleRequest(APIGatewayV2HTTPEvent request,
             Context context) {

--- a/src/main/java/otto/storage/ConcurrentDocumentChange.java
+++ b/src/main/java/otto/storage/ConcurrentDocumentChange.java
@@ -1,0 +1,21 @@
+package otto.storage;
+
+/**
+ * Two runs changed one document, and neither may win. The later run's
+ * copy was derived from a version that no longer exists, so storing it
+ * would erase what the other run stored.
+ *
+ * <p>This is a storage-seam concept rather than an S3 one: any backend
+ * that lets two entry points write at once can raise it, and callers
+ * decide what a lost run costs them. The Check lets it fail, because
+ * the next Check is a minute away. The webhook asks Telegram to send
+ * the update again, because the tap it carries is the user's and there
+ * is no next one.
+ */
+public class ConcurrentDocumentChange extends IllegalStateException {
+
+    public ConcurrentDocumentChange(String name) {
+        super("The other entry point changed " + name + " while this run held it."
+                + " This run's copy is dropped rather than written over it.");
+    }
+}

--- a/src/main/java/otto/storage/DocumentBackend.java
+++ b/src/main/java/otto/storage/DocumentBackend.java
@@ -1,0 +1,27 @@
+package otto.storage;
+
+import java.util.Optional;
+
+/**
+ * Where a stored document's bytes live. {@link JsonStore} owns the
+ * JSON; a backend owns durability. The split is what lets the laptop
+ * keep a directory of files while the deployed assistant keeps an
+ * object in S3 and a table in DynamoDB, with no caller changing.
+ */
+public interface DocumentBackend {
+
+    /** The stored bytes of one document, or empty when it has none yet. */
+    Optional<byte[]> load(String name);
+
+    /** Stores the bytes of one document under its name. */
+    void store(String name, byte[] json);
+
+    /**
+     * Ends one run: a backend that batches writes pushes them here. A
+     * backend that writes each document straight through does nothing.
+     * The Check calls this once per run, so a minute of writes costs
+     * one round trip rather than one per document.
+     */
+    default void flush() {
+    }
+}

--- a/src/main/java/otto/storage/FileDocumentBackend.java
+++ b/src/main/java/otto/storage/FileDocumentBackend.java
@@ -1,0 +1,65 @@
+package otto.storage;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.AtomicMoveNotSupportedException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.Optional;
+
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+import otto.OttoProperties;
+
+/**
+ * The laptop's storage: one JSON file per named document under the
+ * configured directory. Writes go to a temp file first and move into
+ * place, so a crash mid-write never leaves a torn document.
+ */
+@Component
+@Profile("!aws")
+public class FileDocumentBackend implements DocumentBackend {
+
+    private final Path dir;
+
+    public FileDocumentBackend(OttoProperties properties) {
+        this.dir = Path.of(properties.storageDir());
+    }
+
+    @Override
+    public Optional<byte[]> load(String name) {
+        Path file = fileFor(name);
+        if (!Files.exists(file)) {
+            return Optional.empty();
+        }
+        try {
+            return Optional.of(Files.readAllBytes(file));
+        } catch (IOException e) {
+            throw new UncheckedIOException("Cannot read stored document " + name, e);
+        }
+    }
+
+    @Override
+    public void store(String name, byte[] json) {
+        Path file = fileFor(name);
+        try {
+            Files.createDirectories(dir);
+            Path temp = Files.createTempFile(dir, name, ".tmp");
+            Files.write(temp, json);
+            try {
+                Files.move(temp, file,
+                        StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
+            } catch (AtomicMoveNotSupportedException e) {
+                Files.move(temp, file, StandardCopyOption.REPLACE_EXISTING);
+            }
+        } catch (IOException e) {
+            throw new UncheckedIOException("Cannot write stored document " + name, e);
+        }
+    }
+
+    private Path fileFor(String name) {
+        return dir.resolve(name + ".json");
+    }
+}

--- a/src/main/java/otto/storage/JsonStore.java
+++ b/src/main/java/otto/storage/JsonStore.java
@@ -2,31 +2,25 @@ package otto.storage;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
-import java.nio.file.AtomicMoveNotSupportedException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.StandardCopyOption;
 import java.util.Optional;
 
 import com.fasterxml.jackson.databind.JavaType;
 import org.springframework.stereotype.Component;
 
-import otto.OttoProperties;
-
 /**
- * Local document storage: one JSON file per named document under the
- * configured storage directory. Writes go to a temp file first and
- * move into place, so a crash mid-write never leaves a torn document.
- * This class is the storage seam: a cloud object-store adapter can
- * replace it without touching callers.
+ * Document storage: one JSON document per name. This class is the
+ * storage seam every caller holds. It turns a document into JSON and
+ * back and hands the bytes to a {@link DocumentBackend}, so where the
+ * bytes live - a directory of files, an object in S3, a row in
+ * DynamoDB - is settled in one place.
  */
 @Component
 public class JsonStore {
 
-    private final Path dir;
+    private final DocumentBackend backend;
 
-    public JsonStore(OttoProperties properties) {
-        this.dir = Path.of(properties.storageDir());
+    public JsonStore(DocumentBackend backend) {
+        this.backend = backend;
     }
 
     public <T> Optional<T> read(String name, Class<T> type) {
@@ -34,35 +28,35 @@ public class JsonStore {
     }
 
     public <T> Optional<T> read(String name, JavaType type) {
-        Path file = fileFor(name);
-        if (!Files.exists(file)) {
+        Optional<byte[]> stored = backend.load(name);
+        if (stored.isEmpty()) {
             return Optional.empty();
         }
         try {
-            return Optional.of(OttoJson.MAPPER.readValue(file.toFile(), type));
+            return Optional.of(OttoJson.MAPPER.readValue(stored.get(), type));
         } catch (IOException e) {
             throw new UncheckedIOException("Cannot read stored document " + name, e);
         }
     }
 
     public void write(String name, Object value) {
-        Path file = fileFor(name);
         try {
-            Files.createDirectories(dir);
-            Path temp = Files.createTempFile(dir, name, ".tmp");
-            OttoJson.MAPPER.writerWithDefaultPrettyPrinter().writeValue(temp.toFile(), value);
-            try {
-                Files.move(temp, file,
-                        StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
-            } catch (AtomicMoveNotSupportedException e) {
-                Files.move(temp, file, StandardCopyOption.REPLACE_EXISTING);
-            }
+            backend.store(name,
+                    OttoJson.MAPPER.writerWithDefaultPrettyPrinter().writeValueAsBytes(value));
         } catch (IOException e) {
             throw new UncheckedIOException("Cannot write stored document " + name, e);
         }
     }
 
-    private Path fileFor(String name) {
-        return dir.resolve(name + ".json");
+    /**
+     * Ends one run, so a backend that batches writes pushes them. The
+     * deployed entry points call this once their work is done, failed
+     * or not: a Check that half finished still stored what it learned.
+     * The local drivers do not, and need not - a laptop's backend
+     * stores each document as it comes rather than a run's worth at a
+     * time, so there is nothing held back to push.
+     */
+    public void flush() {
+        backend.flush();
     }
 }

--- a/src/main/resources/META-INF/spring.factories
+++ b/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,2 @@
+org.springframework.boot.EnvironmentPostProcessor=\
+otto.aws.SsmSecrets

--- a/src/main/resources/application-aws.yml
+++ b/src/main/resources/application-aws.yml
@@ -1,0 +1,12 @@
+# The deployed assistant. The stack names the bucket and the table and
+# passes both in; the secrets arrive from SSM before this file is read.
+otto:
+  aws:
+    bucket: "${OTTO_BUCKET}"
+    table: "${OTTO_TABLE}"
+
+logging:
+  pattern:
+    # CloudWatch stamps every line already, and the request id comes
+    # from the Lambda runtime, so the pattern carries only the message.
+    console: "%-5level %logger{36} - %msg%n"

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -48,3 +48,9 @@ spring:
       chat:
         options:
           model: "gpt-5.6-luna"
+          # The Ask loop offers the model a tool on every call, and this
+          # model refuses tools on the chat-completions endpoint unless
+          # reasoning is off. It is also what this assistant wants: the
+          # thinking is done in Java, and the model only writes the
+          # sentence, so reasoning effort buys latency and nothing else.
+          reasoning-effort: "none"

--- a/src/test/java/otto/AskScenarioTest.java
+++ b/src/test/java/otto/AskScenarioTest.java
@@ -88,6 +88,24 @@ class AskScenarioTest extends WireSeamTest {
                 .withRequestBody(notContaining("99.9")));
     }
 
+    /**
+     * The model is offered a tool on every Ask, and this model refuses
+     * tools on the chat-completions endpoint unless reasoning is off.
+     * A stub answers whatever it is asked, so nothing else here would
+     * notice the combination the real endpoint rejects.
+     */
+    @Test
+    void everyCallAsksForNoReasoningSoTheToolsAreAccepted() {
+        snapshotWithABenchEdge();
+        OutboundStubs.telegramOk(telegram);
+        OutboundStubs.llmPhrases(llm, "Anything you like.");
+
+        ask("what should I do this week?");
+
+        llm.verify(1, postRequestedFor(urlPathMatching(OutboundStubs.CHAT_COMPLETIONS_PATH))
+                .withRequestBody(containing("\"reasoning_effort\":\"none\"")));
+    }
+
     @Test
     void theModelIsOfferedEveryLaneATool() {
         snapshotWithABenchEdge();

--- a/src/test/java/otto/AwsStorageScenarioTest.java
+++ b/src/test/java/otto/AwsStorageScenarioTest.java
@@ -12,6 +12,7 @@ import otto.aws.DynamoDbBackend;
 import otto.aws.S3BundleBackend;
 import otto.harness.FakeDynamoDb;
 import otto.harness.FakeS3;
+import otto.storage.ConcurrentDocumentChange;
 import otto.storage.DocumentBackend;
 import otto.storage.JsonStore;
 
@@ -147,7 +148,7 @@ class AwsStorageScenarioTest {
         check.write("event-log", List.of("alert sent", "alert sent again"));
 
         assertThatThrownBy(check::flush)
-                .isInstanceOf(S3BundleBackend.ConcurrentDocumentChange.class)
+                .isInstanceOf(ConcurrentDocumentChange.class)
                 .hasMessageContaining("event-log");
         assertThat(s3.storedAsText(KEY)).contains("the user tapped done");
     }
@@ -157,7 +158,7 @@ class AwsStorageScenarioTest {
         store.write("event-log", List.of("mine"));
         s3.writeBehindTheCaller(KEY, "{\"event-log\":[\"theirs\"]}".getBytes());
         assertThatThrownBy(store::flush)
-                .isInstanceOf(S3BundleBackend.ConcurrentDocumentChange.class);
+                .isInstanceOf(ConcurrentDocumentChange.class);
 
         store.write("settings", new Settings(true, 1.0));
         store.flush();

--- a/src/test/java/otto/AwsStorageScenarioTest.java
+++ b/src/test/java/otto/AwsStorageScenarioTest.java
@@ -1,0 +1,233 @@
+package otto;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import otto.aws.AwsDocumentBackend;
+import otto.aws.DocumentPlacement;
+import otto.aws.DynamoDbBackend;
+import otto.aws.S3BundleBackend;
+import otto.harness.FakeDynamoDb;
+import otto.harness.FakeS3;
+import otto.storage.DocumentBackend;
+import otto.storage.JsonStore;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * What the deployed assistant does with its documents. The big ones go
+ * to S3 as one object a run; the small ones go to DynamoDB one at a
+ * time; and two entry points writing at once cost neither of them
+ * their work.
+ */
+class AwsStorageScenarioTest {
+
+    private static final String BUCKET = "otto-documents";
+    private static final String TABLE = "otto-records";
+    private static final String KEY = "documents.json";
+
+    private FakeS3 s3;
+    private FakeDynamoDb dynamo;
+    private JsonStore store;
+
+    /** A big document and a small one, in the language the app stores. */
+    record Snapshot(String week, List<String> starters) {
+    }
+
+    record Settings(boolean alertsOn, double edgeThreshold) {
+    }
+
+    @BeforeEach
+    void newStorage() {
+        s3 = new FakeS3();
+        dynamo = new FakeDynamoDb();
+        store = new JsonStore(backend());
+    }
+
+    private DocumentBackend backend() {
+        return new AwsDocumentBackend(
+                new S3BundleBackend(s3, BUCKET), new DynamoDbBackend(dynamo, TABLE));
+    }
+
+    @Test
+    void aDocumentWithNoStoredValueReadsEmpty() {
+        assertThat(store.read("snapshot-current", Snapshot.class)).isEmpty();
+        assertThat(store.read("settings", Settings.class)).isEmpty();
+    }
+
+    @Test
+    void aRunOfBigDocumentsCostsOneWrite() {
+        store.write("snapshot-current", new Snapshot("2", List.of("Kamara")));
+        store.write("snapshot-previous", new Snapshot("1", List.of("Pollard")));
+        store.write("event-log", List.of("dropped"));
+
+        assertThat(s3.writes()).as("nothing is stored before the run ends").isZero();
+
+        store.flush();
+
+        assertThat(s3.writes()).isEqualTo(1);
+        assertThat(s3.storedAsText(KEY))
+                .contains("snapshot-current", "snapshot-previous", "event-log");
+    }
+
+    @Test
+    void aBigDocumentReadsBackWhatTheSameRunWrote() {
+        store.write("snapshot-current", new Snapshot("2", List.of("Kamara")));
+
+        assertThat(store.read("snapshot-current", Snapshot.class))
+                .contains(new Snapshot("2", List.of("Kamara")));
+    }
+
+    @Test
+    void aBigDocumentSurvivesTheRunThatWroteIt() {
+        store.write("snapshot-current", new Snapshot("2", List.of("Kamara")));
+        store.flush();
+
+        JsonStore laterRun = new JsonStore(backend());
+
+        assertThat(laterRun.read("snapshot-current", Snapshot.class))
+                .contains(new Snapshot("2", List.of("Kamara")));
+    }
+
+    @Test
+    void aSmallRecordIsStoredAtOnceAndNotInTheBundle() {
+        store.write("settings", new Settings(true, 1.0));
+
+        assertThat(dynamo.writes()).isEqualTo(1);
+        assertThat(dynamo.holds("settings")).isTrue();
+        assertThat(store.read("settings", Settings.class)).contains(new Settings(true, 1.0));
+
+        store.flush();
+
+        assertThat(s3.writes()).as("a small record never reaches the bundle").isZero();
+    }
+
+    @Test
+    void theOtherEntryPointsWriteIsKeptWhenThisOneLands() {
+        store.write("snapshot-current", new Snapshot("2", List.of("Kamara")));
+        store.flush();
+
+        // The webhook appends to the Event Log between this run's read
+        // and its write, the way a button tap does.
+        JsonStore check = new JsonStore(backend());
+        check.read("snapshot-current", Snapshot.class);
+        s3.writeBehindTheCaller(KEY, """
+                {"snapshot-current":{"week":"2","starters":["Kamara"]},\
+                "event-log":["ignored the flex alert"]}""".getBytes());
+
+        check.write("snapshot-current", new Snapshot("3", List.of("Nacua")));
+        check.flush();
+
+        assertThat(s3.storedAsText(KEY))
+                .as("the run that landed second keeps both writers' work")
+                .contains("ignored the flex alert")
+                .contains("Nacua");
+    }
+
+    /**
+     * The Event Log is the one document both entry points append to. A
+     * run that read it, appended, and met the other writer's append
+     * cannot write its own copy over the top - the user's tap is in the
+     * other one.
+     */
+    @Test
+    void aTapTheOtherEntryPointStoredIsNotWrittenOver() {
+        store.write("event-log", List.of("alert sent"));
+        store.flush();
+
+        JsonStore check = new JsonStore(backend());
+        check.read("event-log", Object.class);
+        s3.writeBehindTheCaller(KEY, """
+                {"event-log":["alert sent","the user tapped done"]}""".getBytes());
+
+        check.write("event-log", List.of("alert sent", "alert sent again"));
+
+        assertThatThrownBy(check::flush)
+                .isInstanceOf(S3BundleBackend.ConcurrentDocumentChange.class)
+                .hasMessageContaining("event-log");
+        assertThat(s3.storedAsText(KEY)).contains("the user tapped done");
+    }
+
+    @Test
+    void aRefusedRunDoesNotApplyItsDocumentsToTheNextOne() {
+        store.write("event-log", List.of("mine"));
+        s3.writeBehindTheCaller(KEY, "{\"event-log\":[\"theirs\"]}".getBytes());
+        assertThatThrownBy(store::flush)
+                .isInstanceOf(S3BundleBackend.ConcurrentDocumentChange.class);
+
+        store.write("settings", new Settings(true, 1.0));
+        store.flush();
+
+        assertThat(s3.storedAsText(KEY)).contains("theirs").doesNotContain("mine");
+    }
+
+    @Test
+    void aRunThatChangedNothingReReadsWithoutABody() {
+        store.write("snapshot-current", new Snapshot("2", List.of("Kamara")));
+        store.flush();
+        int servedByTheFirstRun = s3.bodiesServed();
+
+        store.read("snapshot-current", Snapshot.class);
+        store.read("event-log", Object.class);
+
+        assertThat(s3.bodiesServed())
+                .as("the held bundle is confirmed, not fetched again")
+                .isEqualTo(servedByTheFirstRun);
+    }
+
+    @Test
+    void aBundleThatIsNotAJsonObjectIsRefusedRatherThanRead() {
+        s3.writeBehindTheCaller(KEY, "[\"not an object\"]".getBytes());
+
+        assertThatThrownBy(() -> store.read("snapshot-current", Snapshot.class))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining(KEY);
+    }
+
+    @Test
+    void everyDocumentTheAssistantStoresHasAPlace() {
+        List<String> big = List.of("snapshot-current", "snapshot-previous", "player-directory",
+                "defense-versus-position", "event-log", "nflverse-weekly-stats",
+                "nflverse-depth-charts", "nflverse-weekly-rosters", "nflverse-player-ids");
+        List<String> small = List.of("settings", "watchlist", "watchlist-observations",
+                "mutes", "conversation", "last-check", "alert-id-sequence",
+                "telegram-updates");
+
+        assertThat(big).allMatch(DocumentPlacement::isBig);
+        assertThat(small).noneMatch(DocumentPlacement::isBig);
+    }
+
+    /**
+     * A document nobody has placed goes to the store that cannot be
+     * outgrown. The other way round, the mistake would surface as a
+     * failed write in the middle of a season.
+     */
+    @Test
+    void aDocumentNobodyHasPlacedGoesToTheStoreWithNoSizeLimit() {
+        assertThat(DocumentPlacement.isBig("nflverse-something-new")).isTrue();
+        assertThat(DocumentPlacement.isBig("a-document-added-next-season")).isTrue();
+    }
+
+    @Test
+    void anEmptyRunStoresNothing() {
+        store.flush();
+
+        assertThat(s3.writes()).isZero();
+        assertThat(dynamo.writes()).isZero();
+    }
+
+    @Test
+    void aSmallRecordSurvivesTheRunThatWroteIt() {
+        store.write("watchlist", List.of("Nacua"));
+
+        Optional<List<String>> read = new JsonStore(backend())
+                .read("watchlist", otto.storage.OttoJson.MAPPER.getTypeFactory()
+                        .constructCollectionType(List.class, String.class));
+
+        assertThat(read).contains(List.of("Nacua"));
+    }
+}

--- a/src/test/java/otto/SettingsScenarioTest.java
+++ b/src/test/java/otto/SettingsScenarioTest.java
@@ -12,6 +12,7 @@ import otto.harness.WireSeamTest;
 import otto.lineup.PositionCutoffs;
 import otto.settings.SettingsStore;
 import otto.settings.Trigger;
+import otto.storage.FileDocumentBackend;
 import otto.storage.JsonStore;
 import otto.telegram.TelegramWebhook;
 import otto.telegram.WebhookResult;
@@ -232,7 +233,7 @@ class SettingsScenarioTest extends WireSeamTest {
         settingsAsk("{\"action\":\"set\",\"name\":\"edge_threshold\",\"value\":\"2.5\"}",
                 "two and a half points");
 
-        SettingsStore coldRead = new SettingsStore(new JsonStore(properties), properties);
+        SettingsStore coldRead = new SettingsStore(new JsonStore(new FileDocumentBackend(properties)), properties);
         assertThat(coldRead.current().edgeThreshold()).isEqualTo(2.5);
         assertThat(coldRead.current().enabled(Trigger.WATCHLIST)).isTrue();
     }

--- a/src/test/java/otto/WatchlistScenarioTest.java
+++ b/src/test/java/otto/WatchlistScenarioTest.java
@@ -17,6 +17,7 @@ import otto.events.EventType;
 import otto.harness.OutboundStubs;
 import otto.harness.SleeperStubs;
 import otto.harness.WireSeamTest;
+import otto.storage.FileDocumentBackend;
 import otto.storage.JsonStore;
 import otto.telegram.TelegramWebhook;
 import otto.telegram.WebhookResult;
@@ -684,7 +685,7 @@ class WatchlistScenarioTest extends WireSeamTest {
         nextCheck();
         checkRunner.runCheck();
 
-        WatchlistStore coldRead = new WatchlistStore(new JsonStore(properties));
+        WatchlistStore coldRead = new WatchlistStore(new JsonStore(new FileDocumentBackend(properties)));
         assertThat(coldRead.all()).singleElement()
                 .satisfies(entry -> {
                     assertThat(entry.playerId()).isEqualTo(NACUA);

--- a/src/test/java/otto/aws/AwsEntryPointScenarioTest.java
+++ b/src/test/java/otto/aws/AwsEntryPointScenarioTest.java
@@ -7,11 +7,14 @@ import java.util.Map;
 import java.util.Properties;
 
 import com.amazonaws.services.lambda.runtime.events.APIGatewayV2HTTPEvent;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayV2HTTPResponse;
 import com.amazonaws.services.lambda.runtime.events.SNSEvent;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.EnvironmentPostProcessor;
 import org.springframework.boot.SpringApplication;
 import org.springframework.mock.env.MockEnvironment;
+
+import otto.storage.ConcurrentDocumentChange;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -64,6 +67,33 @@ class AwsEntryPointScenarioTest {
         assertThat(webhook.body(request(Map.of(), encoded, true))).isEqualTo(update);
         assertThat(webhook.body(request(Map.of(), update, false))).isEqualTo(update);
         assertThat(webhook.body(request(Map.of(), null, false))).isEmpty();
+    }
+
+    /**
+     * The tap is the user's, and nothing else will retry it. He has
+     * already seen the acknowledgement, so a dropped storage write
+     * would leave him told that a Done he never stored had worked.
+     */
+    @Test
+    void aTapWhoseStorageWasRefusedIsAskedForAgain() {
+        APIGatewayV2HTTPResponse answer =
+                webhook.recoverFrom(new ConcurrentDocumentChange("event-log"));
+
+        assertThat(answer.getStatusCode())
+                .as("any answer that is not a success makes Telegram send it again")
+                .isEqualTo(503);
+    }
+
+    /**
+     * A body this build cannot handle would fail the same way on every
+     * retry, so it is let go rather than looped on.
+     */
+    @Test
+    void anUpdateThisBuildCannotHandleIsNotAskedForAgain() {
+        APIGatewayV2HTTPResponse answer =
+                webhook.recoverFrom(new IllegalArgumentException("nonsense update"));
+
+        assertThat(answer.getStatusCode()).isEqualTo(200);
     }
 
     @Test

--- a/src/test/java/otto/aws/AwsEntryPointScenarioTest.java
+++ b/src/test/java/otto/aws/AwsEntryPointScenarioTest.java
@@ -1,0 +1,127 @@
+package otto.aws;
+
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Map;
+import java.util.Properties;
+
+import com.amazonaws.services.lambda.runtime.events.APIGatewayV2HTTPEvent;
+import com.amazonaws.services.lambda.runtime.events.SNSEvent;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.EnvironmentPostProcessor;
+import org.springframework.boot.SpringApplication;
+import org.springframework.mock.env.MockEnvironment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * What the deployed entry points make of what AWS hands them, before
+ * any of it reaches the seams the local build already covers.
+ */
+class AwsEntryPointScenarioTest {
+
+    private final WebhookHandler webhook = new WebhookHandler();
+
+    @Test
+    void everyScheduleNamesAJobTheBuildHas() {
+        assertThat(ScheduledJob.of("check")).isEqualTo(ScheduledJob.CHECK);
+        assertThat(ScheduledJob.of("nflverse-feeds")).isEqualTo(ScheduledJob.NFLVERSE_FEEDS);
+        assertThat(ScheduledJob.of("defense-versus-position"))
+                .isEqualTo(ScheduledJob.DEFENSE_VERSUS_POSITION);
+    }
+
+    @Test
+    void aScheduleThatNamesAJobThisBuildLacksIsRefused() {
+        assertThatThrownBy(() -> ScheduledJob.of("waiver-board"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("waiver-board");
+    }
+
+    @Test
+    void theSecretTokenIsReadWhateverTheRuntimeCallsTheHeader() {
+        assertThat(webhook.secretToken(request(
+                Map.of("x-telegram-bot-api-secret-token", "shh"), "{}", false)))
+                .contains("shh");
+        assertThat(webhook.secretToken(request(
+                Map.of("X-Telegram-Bot-Api-Secret-Token", "shh"), "{}", false)))
+                .contains("shh");
+    }
+
+    @Test
+    void aCallWithNoSecretTokenCarriesNone() {
+        assertThat(webhook.secretToken(request(Map.of(), "{}", false))).isEmpty();
+        assertThat(webhook.secretToken(request(null, "{}", false))).isEmpty();
+    }
+
+    @Test
+    void anEncodedBodyIsDecodedBeforeTheSeamSeesIt() {
+        String update = "{\"update_id\":7}";
+        String encoded = Base64.getEncoder()
+                .encodeToString(update.getBytes(StandardCharsets.UTF_8));
+
+        assertThat(webhook.body(request(Map.of(), encoded, true))).isEqualTo(update);
+        assertThat(webhook.body(request(Map.of(), update, false))).isEqualTo(update);
+        assertThat(webhook.body(request(Map.of(), null, false))).isEmpty();
+    }
+
+    @Test
+    void aForwardedAlarmSaysWhatItIsAbout() {
+        assertThat(new AlarmForwarderHandler().text(sns("ALARM: otto-check-heartbeat")))
+                .contains("otto-check-heartbeat")
+                .contains("CloudWatch");
+    }
+
+    @Test
+    void anAlarmWithNoSubjectStillReachesTheUser() {
+        assertThat(new AlarmForwarderHandler().text(sns(null)))
+                .contains("CloudWatch");
+    }
+
+    /**
+     * The laptop must never reach for Parameter Store. The parameter
+     * path is what turns the lookup on, so an environment without one
+     * adds nothing and calls nothing.
+     */
+    @Test
+    void withNoParameterPathNoSecretsAreLookedUp() {
+        MockEnvironment environment = new MockEnvironment();
+
+        new SsmSecrets().postProcessEnvironment(environment, new SpringApplication());
+
+        assertThat(environment.getPropertySources().contains("otto-ssm-parameters")).isFalse();
+    }
+
+    /**
+     * The secrets reader is found by Spring Boot, not by anything that
+     * imports it, so a wrong key or a stale interface would go unnoticed
+     * until a deployed function could not read a token.
+     */
+    @Test
+    void theSecretsReaderIsRegisteredUnderTheKeySpringBootReads() throws Exception {
+        Properties factories = new Properties();
+        try (InputStream registration =
+                     getClass().getResourceAsStream("/META-INF/spring.factories")) {
+            assertThat(registration).as("META-INF/spring.factories").isNotNull();
+            factories.load(registration);
+        }
+
+        assertThat(factories.getProperty(EnvironmentPostProcessor.class.getName()))
+                .contains(SsmSecrets.class.getName());
+        assertThat(EnvironmentPostProcessor.class).isAssignableFrom(SsmSecrets.class);
+    }
+
+    private APIGatewayV2HTTPEvent request(Map<String, String> headers, String body,
+            boolean encoded) {
+        return APIGatewayV2HTTPEvent.builder()
+                .withHeaders(headers)
+                .withBody(body)
+                .withIsBase64Encoded(encoded)
+                .build();
+    }
+
+    private SNSEvent.SNS sns(String subject) {
+        return new SNSEvent.SNS().withSubject(subject).withMessage("{}");
+    }
+}

--- a/src/test/java/otto/harness/FakeDynamoDb.java
+++ b/src/test/java/otto/harness/FakeDynamoDb.java
@@ -1,0 +1,53 @@
+package otto.harness;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.GetItemRequest;
+import software.amazon.awssdk.services.dynamodb.model.GetItemResponse;
+import software.amazon.awssdk.services.dynamodb.model.PutItemRequest;
+import software.amazon.awssdk.services.dynamodb.model.PutItemResponse;
+
+/** A DynamoDB that lives in memory: one item per document name. */
+public class FakeDynamoDb implements DynamoDbClient {
+
+    private final Map<String, Map<String, AttributeValue>> items = new HashMap<>();
+
+    private int writes;
+
+    @Override
+    public GetItemResponse getItem(GetItemRequest request) {
+        Map<String, AttributeValue> item = items.get(key(request.key()));
+        return GetItemResponse.builder().item(item == null ? Map.of() : item).build();
+    }
+
+    @Override
+    public PutItemResponse putItem(PutItemRequest request) {
+        items.put(key(request.item()), request.item());
+        writes++;
+        return PutItemResponse.builder().build();
+    }
+
+    public boolean holds(String name) {
+        return items.containsKey(name);
+    }
+
+    public int writes() {
+        return writes;
+    }
+
+    private String key(Map<String, AttributeValue> attributes) {
+        return attributes.get("name").s();
+    }
+
+    @Override
+    public String serviceName() {
+        return DynamoDbClient.SERVICE_NAME;
+    }
+
+    @Override
+    public void close() {
+    }
+}

--- a/src/test/java/otto/harness/FakeS3.java
+++ b/src/test/java/otto/harness/FakeS3.java
@@ -1,0 +1,108 @@
+package otto.harness;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import software.amazon.awssdk.core.ResponseBytes;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
+import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectResponse;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+
+/**
+ * An S3 that lives in memory and keeps the three answers the stored
+ * documents depend on: a missing key, a conditional read that finds
+ * nothing changed, and a conditional write that another writer beat.
+ */
+public class FakeS3 implements S3Client {
+
+    private final Map<String, byte[]> objects = new HashMap<>();
+    private final Map<String, String> etags = new HashMap<>();
+
+    private int nextEtag = 1;
+
+    /** How many bodies the caller has actually been sent. */
+    private int bodiesServed;
+
+    /** How many writes the caller has landed. */
+    private int writes;
+
+    @Override
+    public ResponseBytes<GetObjectResponse> getObjectAsBytes(GetObjectRequest request) {
+        byte[] stored = objects.get(request.key());
+        if (stored == null) {
+            throw NoSuchKeyException.builder().statusCode(404).message("no such key").build();
+        }
+        String etag = etags.get(request.key());
+        if (etag.equals(request.ifNoneMatch())) {
+            throw S3Exception.builder().statusCode(304).message("not modified").build();
+        }
+        bodiesServed++;
+        return ResponseBytes.fromByteArray(
+                GetObjectResponse.builder().eTag(etag).build(), stored);
+    }
+
+    @Override
+    public PutObjectResponse putObject(PutObjectRequest request, RequestBody body) {
+        String held = etags.get(request.key());
+        boolean mustNotExist = "*".equals(request.ifNoneMatch());
+        boolean mustMatch = request.ifMatch() != null;
+        if (mustNotExist && held != null) {
+            throw precondition();
+        }
+        if (mustMatch && !request.ifMatch().equals(held)) {
+            throw precondition();
+        }
+        objects.put(request.key(), read(body));
+        String etag = "\"etag-" + nextEtag++ + "\"";
+        etags.put(request.key(), etag);
+        writes++;
+        return PutObjectResponse.builder().eTag(etag).build();
+    }
+
+    /** Stores an object behind the caller's back, as the other entry point would. */
+    public void writeBehindTheCaller(String key, byte[] json) {
+        objects.put(key, json);
+        etags.put(key, "\"etag-" + nextEtag++ + "\"");
+    }
+
+    public String storedAsText(String key) {
+        byte[] stored = objects.get(key);
+        return stored == null ? null : new String(stored);
+    }
+
+    public int bodiesServed() {
+        return bodiesServed;
+    }
+
+    public int writes() {
+        return writes;
+    }
+
+    private RuntimeException precondition() {
+        return S3Exception.builder().statusCode(412).message("precondition failed").build();
+    }
+
+    private byte[] read(RequestBody body) {
+        try {
+            return body.contentStreamProvider().newStream().readAllBytes();
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    @Override
+    public String serviceName() {
+        return S3Client.SERVICE_NAME;
+    }
+
+    @Override
+    public void close() {
+    }
+}


### PR DESCRIPTION
Closes the build side of #19. One CDK stack deploys the whole assistant, so the operator can rebuild the system from this repo.

Deployed live to `us-east-1` during review, which found three faults no synth assertion could. All three are fixed here.

## What this adds

Otto ran only on a laptop: a scheduled method drove the Check, a Telegram long poll fed the Ask loop, and JSON files under `./data` held every document. This adds the cloud side and changes nothing about what the assistant decides.

**Two entry points, one deployable.** A scheduled Lambda runs the Check and the two nflverse jobs, picked by the job named in the schedule payload, so one warm context serves all three. A Lambda function URL takes Telegram's updates and hands them to the same webhook seam the long poll already used. A third function forwards CloudWatch alarms to the chat, separate because what it reports on is the assistant being down.

Both app functions run arm64 on SnapStart. SnapStart snapshots published versions only, so each sits behind an alias, and the schedules and the function URL target the alias.

**Storage** keeps `JsonStore` as the seam every caller holds and gains a backend behind it. Big documents batch into one S3 object per run; small records write through to DynamoDB and read strongly consistent. Both entry points append to the Event Log, so the S3 write carries the ETag the run read and refuses rather than erase a document the other writer also changed.

**Secrets** are SSM SecureStrings, read once before the Spring context is built.

**Observability** is 14-day retention, an error alarm over all three log groups, and a heartbeat alarm treating missing data as breaching, because a stopped Check loop raises no error and simply goes quiet.

## Verified live

| Check | Result |
| --- | --- |
| Check loop runs each minute | Confirmed via the heartbeat log line |
| SnapStart restore | 440-820 ms, against ~2100 ms cold init |
| Secrets read from Parameter Store | Confirmed |
| Both stores read and written | Confirmed |
| Ask loop reaches the model | Blocked by an unrelated model-config fault, see below |
| Heartbeat alarm fires | Not yet exercised |

## What the live deploy found

1. **Reading secrets was denied.** `GetParametersByPath` authorizes against the path, `GetParameter` against the parameters under it. The grant named only the children, which synthesizes cleanly and is refused on the first call.
2. **A failed init outlived its own fix.** The Spring context is built in a static initializer, so a start that throws leaves the class erroneous for the life of the JVM, and SnapStart snapshots that dead JVM into every restored environment. Fixing the permission changed nothing until a new version was published. The start is now caught, so the next invocation retries.
3. **Reserved concurrency could not be set.** It spends from an account-wide pool and AWS refuses a reservation leaving fewer than 10 unreserved, so a new account capped at 10 can reserve nothing. It is now a context value defaulting to 1.

## Testing

181 app tests, 19 stack tests. The stack tests synthesize the template and read the acceptance criteria back off it, including the absence of the eleven resource types the spec rules out and the logical ids of the two stores, which a rename would otherwise swap for empty ones.

`cfn-lint` reports 0 errors. `cfn-guard` reports 5 S3 findings: two are false positives and three are declined deliberately, with reasons recorded in ADR-0008.

## Known gaps

- The final acceptance item of #19, verifying the heartbeat and self-report Alerts live, is only partly done. The heartbeat is confirmed; the alarm has not been made to fire.
- An Alert is sent before the Event Log entry that dedups it is durable, so a crash between the two re-sends it. Same class as #37.
- Stateful and stateless resources share one stack, as #19 specifies. `RemovalPolicy.RETAIN` plus a logical-id test mitigate it.
- No CI, so no `cdk diff` before deploy.

See `docs/adr/0008-aws-deployment.md` for the decisions and `docs/deploy.md` for the runbook.
