### PR TITLE
fix: read the commissioner transaction type, and state the status filter

### DIFF
--- a/docs/adr/0004-league-awareness.md
+++ b/docs/adr/0004-league-awareness.md
@@ -2,6 +2,10 @@
 
 Status: accepted (2026-08-08, issue #15)
 
+Amended (2026-08-13, issue #39): the transaction status vocabulary and
+the `commissioner` transaction type are settled below. Everything #15
+decided stands.
+
 The spec pins the three league tools, the informational Alert triggers,
 the Notable Player cutoffs and the confidence gate. It leaves the
 semantics of each open. This ADR records what implementation decided.
@@ -27,6 +31,83 @@ Tuesday, so a trade agreed in the closing minutes of a week would drop
 out of view the moment the week advanced - and stay out of view for the
 rest of the season. Reading both weeks keeps it in view for as long as
 it is still news, and costs one conditional GET.
+
+## Only a completed transaction is news, and the vocabulary is stated
+
+Sleeper's own code names six transaction statuses: `proposed`,
+`pending`, `cancelled`, `failed`, `complete` and `rejected`. A scan of
+284,671 live rows across 6,250 leagues in 2026 saw only `complete` and
+`failed` on `transactions/{week}`. The others exist inside the product
+and are not served there.
+
+`pending` is the one worth naming. Sleeper's app shows a trade that has
+been accepted and is inside the commissioner review window; the
+documented endpoint does not publish that state, and the scan confirms
+it - 20% of completed trades in a subsample sat more than a day between
+`created` and `status_updated`, so review windows were open while the
+scan ran and not one `pending` row appeared. An Alert that waits for
+that state would never fire, and the internal endpoint that serves it is
+undocumented and unversioned, which is the thing the spec ruled out when
+it ruled out scraping.
+
+`TransactionStatus` therefore holds the whole vocabulary, marks
+`complete` as the only accepted one, and states on each of the others
+why it is refused. This used to be an inline comparison against the
+string `complete`, which was right by the way the line was written
+rather than by a stated rule - and the difference matters the day
+Sleeper starts publishing a status the line has never seen.
+
+A status outside the vocabulary is dropped and logged with its
+transaction id. Reading an unknown status as news would put a move that
+may never have happened in the user's pocket; dropping it in silence
+would leave a Sleeper change nobody could find. It is one row, not the
+whole read, so the week's real activity still arrives: this is not
+schema drift, where the shape of the feed has stopped being readable.
+
+## A Commissioner Edit is a trade's fact in different words
+
+`commissioner` is the fourth transaction type - undocumented, and 6,377
+rows of it observed live. It is how a roster changes when nobody on it
+agreed to anything, and a player leaving the user's roster that way is
+as much news as any trade.
+
+A player who appears in both a transaction's adds and its drops crossed
+from one roster to another. A Commissioner Edit that does that produces
+the same per-player events a trade does; only the kind differs, and
+with it the sentence. One that adds a player from free agency, or cuts
+one to it, is already an add or a drop and rides with the rest.
+
+The message says "Commissioner edit", not "League trade", because
+calling it a trade would name an agreement that never happened. It
+rides at High for the same reason a trade does: it is a fact, and it is
+already done. It carries the same trigger and the same mute class as a
+trade - the user who asked to hear about players changing hands meant
+this too, and a second class to mute would be vocabulary he never asked
+for.
+
+A Commissioner Edit elsewhere in the league sends whoever it touched,
+the way a trade between two other managers does, rather than waiting on
+the Notable Player cutoffs. The cutoffs answer "is this man worth a
+claim"; nobody can claim a player who is already on another roster, and
+the news here is that the league's rules moved him.
+
+## A cut the commissioner made is not a cut the user made
+
+A player can also leave the user's roster with nobody gaining him.
+That is a drop, and drops on the user's own roster are filtered out as
+his own decision - which is true when he made it and false when the
+commissioner did, and the two are identical in roster state.
+
+So every event a Commissioner Edit produces is stamped as one, and the
+filter reads the stamp. His own cut still stays quiet; the
+commissioner's cut sends at High, states the loss and names the slot it
+opened. It does not go near the Notable cutoffs: he is short a player
+he chose to hold, whatever the projection table thinks of the man.
+
+The fifth type, `chopped`, was not observed live and gets no words of
+its own. It needs none: a type this code does not name is read by what
+it did to the rosters - an add, a drop - and never earns a sentence
+that names an actor nobody has seen act.
 
 ## The Event Log keeps the facts; the detector keeps the words
 

--- a/src/main/java/otto/alerts/AlertActions.java
+++ b/src/main/java/otto/alerts/AlertActions.java
@@ -9,6 +9,7 @@ import java.util.Optional;
 
 import org.springframework.stereotype.Component;
 
+import otto.events.DiffKind;
 import otto.events.Event;
 import otto.events.EventLog;
 import otto.events.EventType;
@@ -86,8 +87,12 @@ public class AlertActions {
                 .map(event -> event.key().substring("alert:".length()))
                 .toList();
         // A trade names several players, so muting it can only mean the
-        // class: the user is saying he does not want trade news.
-        if (problemKeys.stream().anyMatch(key -> key.startsWith("trade:"))) {
+        // class: the user is saying he does not want trade news. A
+        // Commissioner Edit that sent a player across is the same news
+        // by another route, and it goes quiet with it.
+        if (problemKeys.stream().anyMatch(key ->
+                key.startsWith(DiffKind.TRADE.fact() + ":")
+                        || key.startsWith(DiffKind.COMMISSIONER.fact() + ":"))) {
             return AlertCandidate.Source.TRADE.muteClass();
         }
         // News about one player - a status change, a drop, a Watchlist

--- a/src/main/java/otto/alerts/AlertCandidate.java
+++ b/src/main/java/otto/alerts/AlertCandidate.java
@@ -40,6 +40,12 @@ public record AlertCandidate(
         LEGALITY(Trigger.LINEUP_LEGALITY, "class:legality", false),
         EDGE(Trigger.BENCH_EDGE, "class:edge", false),
         WATCHLIST(Trigger.WATCHLIST, "class:watchlist", true),
+        /**
+         * A player changed rosters: a trade, or the Commissioner Edit
+         * that does the same thing without anyone agreeing to it. Both
+         * are the news the user opted into when he asked to hear about
+         * trades, so one mute class covers them.
+         */
         TRADE(Trigger.LEAGUE_ACTIVITY, "class:trade", false),
         DROP(Trigger.LEAGUE_ACTIVITY, "class:drop", true);
 

--- a/src/main/java/otto/alerts/LeagueActivityDetector.java
+++ b/src/main/java/otto/alerts/LeagueActivityDetector.java
@@ -20,19 +20,22 @@ import otto.lineup.PositionCutoffs;
 import otto.lineup.PositionRanking;
 import otto.lineup.PositionRankings;
 import otto.settings.SettingsStore;
+import otto.snapshot.SnapshotDiffer;
 
 /**
- * Turns league activity into Alert candidates: any trade, and the drop
- * of a Notable Player.
+ * Turns league activity into Alert candidates: any trade, any
+ * Commissioner Edit that sent a player across to another roster or
+ * took one off the user's, and the drop of a Notable Player.
  *
- * Both are informational - they report what another manager did, and
- * the user's own lineup is untouched - so they carry no swap and never
- * join the Lock Ladder. The confidence gate still governs what he
- * hears. A completed trade is a fact, so it rides at High and states
- * itself. A dropped Notable Player is a judgement about a claim, so it
- * rides at Medium with the case for and against. Any other drop rides
- * at Low, which the gate never sends: a replacement-level player
- * changing hands is an answer to a question, not a text message.
+ * All of it is informational - it reports what somebody else did, and
+ * there is no lineup swap to make - so none of it carries a swap or
+ * joins the Lock Ladder. The confidence gate still governs what he
+ * hears. A completed transaction is a fact, so it rides at High and
+ * states itself. A dropped Notable Player is a judgement about a
+ * claim, so it rides at Medium with the case for and against. Any
+ * other drop rides at Low, which the gate never sends: a
+ * replacement-level player changing hands is an answer to a question,
+ * not a text message.
  */
 @Component
 public class LeagueActivityDetector {
@@ -53,21 +56,21 @@ public class LeagueActivityDetector {
      * event would price the same week over and over.
      */
     public List<AlertCandidate> detect(List<Event> events, WeekFacts week) {
-        List<Event> trades = of(events, DiffKind.TRADE);
+        List<AlertCandidate> candidates = new ArrayList<>();
+        for (Crossing crossing : Crossing.values()) {
+            byTransaction(of(events, crossing.kind())).forEach((transactionId, crossed) ->
+                    candidates.add(crossedRosters(crossing, transactionId, crossed)));
+        }
         // A player the user dropped himself is not news to him, and
         // advising a claim on the man he just cut would be absurd. A
         // trade of his own still sends: it changes his lineup, and one
-        // confirmation of what he agreed to is worth having.
+        // confirmation of what he agreed to is worth having. So does a
+        // Commissioner Edit on his roster: it looks the same in roster
+        // state and he decided none of it.
         List<Event> drops = of(events, DiffKind.DROP).stream()
-                .filter(event -> !"true".equals(event.facts().get("userRoster")))
+                .filter(event -> !"true".equals(event.facts().get("userRoster"))
+                        || byCommissioner(event))
                 .toList();
-        if (trades.isEmpty() && drops.isEmpty()) {
-            return List.of();
-        }
-
-        List<AlertCandidate> candidates = new ArrayList<>();
-        byTransaction(trades).forEach((transactionId, moves) ->
-                candidates.add(trade(transactionId, moves)));
         if (!drops.isEmpty()) {
             Optional<PositionRanking> ranking = week.projections().flatMap(rankings::rank);
             drops.forEach(event -> candidates.add(drop(event, ranking)));
@@ -89,22 +92,67 @@ public class LeagueActivityDetector {
     }
 
     /**
-     * One trade, however many players crossed. The teams and the moves
-     * are read off the per-player events rather than stored as a
-     * sentence, so the Event Log keeps the facts and this keeps the
+     * The two ways a player crosses from one roster to another, and the
+     * words each earns. The facts are the same either way - he is on a
+     * different team and it is already done - so only the sentences
+     * differ, and they live together here rather than as branches down
+     * the middle of the message.
+     *
+     * The key prefix is the diff kind's own name, so the Event Log, the
+     * Alert key and the Mute button all spell one thing one way.
+     */
+    private enum Crossing {
+
+        TRADE(DiffKind.TRADE,
+                "League trade",
+                "%s agreed it, and it is already done",
+                "This one is yours, so your roster has changed"),
+        COMMISSIONER_EDIT(DiffKind.COMMISSIONER,
+                "Commissioner edit",
+                "The commissioner made it, and it is already done",
+                "This one is yours: your roster changed without your say");
+
+        private final DiffKind kind;
+        private final String headline;
+        private final String because;
+        private final String yours;
+
+        Crossing(DiffKind kind, String headline, String because, String yours) {
+            this.kind = kind;
+            this.headline = headline;
+            this.because = because;
+            this.yours = yours;
+        }
+
+        DiffKind kind() {
+            return kind;
+        }
+
+        String key(String transactionId) {
+            return "%s:%s".formatted(kind.fact(), transactionId);
+        }
+    }
+
+    /**
+     * One transaction that changed who holds a player, however many
+     * players crossed: a trade, or a Commissioner Edit that did the
+     * same thing without anyone agreeing to it. The teams and the
+     * players are read off the per-player events rather than stored as
+     * a sentence, so the Event Log keeps the facts and this keeps the
      * words.
      */
-    private AlertCandidate trade(String transactionId, List<Event> moves) {
+    private AlertCandidate crossedRosters(Crossing crossing, String transactionId,
+            List<Event> crossed) {
         Set<String> managers = new LinkedHashSet<>();
         List<String> lines = new ArrayList<>();
         boolean userInvolved = false;
-        for (Event move : moves) {
-            String to = move.facts().getOrDefault("toManager", "");
-            String from = move.facts().getOrDefault("fromManager", "");
+        for (Event event : crossed) {
+            String to = event.facts().getOrDefault("toManager", "");
+            String from = event.facts().getOrDefault("fromManager", "");
             managers.add(from);
             managers.add(to);
-            lines.add("%s to %s".formatted(move.facts().getOrDefault("player", "a player"), to));
-            userInvolved |= "true".equals(move.facts().get("userInvolved"));
+            lines.add("%s to %s".formatted(event.facts().getOrDefault("player", "a player"), to));
+            userInvolved |= "true".equals(event.facts().get("userInvolved"));
         }
         managers.remove("");
         String teams = String.join(" and ", managers);
@@ -113,11 +161,11 @@ public class LeagueActivityDetector {
         Recommendation recommendation = new Recommendation(
                 null,
                 teams,
-                "League trade: %s".formatted(swap),
+                "%s: %s".formatted(crossing.headline, swap),
                 Confidence.HIGH,
-                List.of("%s agreed it, and it is already done".formatted(teams),
+                List.of(crossing.because.formatted(teams),
                         userInvolved
-                                ? "This one is yours, so your roster has changed"
+                                ? crossing.yours
                                 : "Nothing to do: this is a power shift to know about"),
                 List.of());
 
@@ -128,7 +176,7 @@ public class LeagueActivityDetector {
         facts.put("userInvolved", String.valueOf(userInvolved));
         return new AlertCandidate(
                 AlertCandidate.Source.TRADE,
-                "trade:" + transactionId,
+                crossing.key(transactionId),
                 null,
                 "",
                 recommendation,
@@ -141,6 +189,11 @@ public class LeagueActivityDetector {
      * the drop stays at Low and says why: an unranked player is one this
      * system cannot judge, which is not the same as one who does not
      * matter.
+     *
+     * A player cut off the user's own roster by a Commissioner Edit is
+     * the exception, and it does not go near the cutoffs. He has lost a
+     * player he chose to hold, whatever the projection table thinks of
+     * him, and that is a fact rather than a judgement about a claim.
      */
     private AlertCandidate drop(Event event, Optional<PositionRanking> ranking) {
         String playerId = event.facts().getOrDefault("playerId", "");
@@ -149,9 +202,14 @@ public class LeagueActivityDetector {
         String manager = event.facts().getOrDefault("fromManager", "another manager");
 
         Map<String, String> facts = new HashMap<>(event.facts());
-        Recommendation recommendation = ranking
-                .map(ranked -> judge(ranked, playerId, player, position, manager, facts))
-                .orElseGet(() -> unranked(playerId, player, manager, facts));
+        Recommendation recommendation;
+        if (byCommissioner(event) && "true".equals(event.facts().get("userRoster"))) {
+            recommendation = commissionerCut(playerId, player, position);
+        } else {
+            recommendation = ranking
+                    .map(ranked -> judge(ranked, playerId, player, position, manager, facts))
+                    .orElseGet(() -> unranked(playerId, player, manager, facts));
+        }
         return new AlertCandidate(
                 AlertCandidate.Source.DROP,
                 event.key(),
@@ -159,6 +217,29 @@ public class LeagueActivityDetector {
                 event.facts().getOrDefault("team", ""),
                 recommendation,
                 facts);
+    }
+
+    /**
+     * The commissioner took a player off the user's roster. Nobody
+     * asked him, so this states what happened and points at the hole it
+     * left rather than weighing anything.
+     */
+    private static Recommendation commissionerCut(String playerId, String player,
+            String position) {
+        return new Recommendation(
+                playerId,
+                player,
+                "Commissioner edit: %s is off your roster".formatted(player),
+                Confidence.HIGH,
+                List.of("The commissioner made it, and it is already done",
+                        "You are a %s short until you fill the slot".formatted(
+                                position.isBlank() ? "player" : position)),
+                List.of());
+    }
+
+    /** True when a Commissioner Edit produced this event. */
+    private static boolean byCommissioner(Event event) {
+        return "true".equals(event.facts().get(SnapshotDiffer.BY_COMMISSIONER));
     }
 
     private Recommendation judge(PositionRanking ranking, String playerId, String player,

--- a/src/main/java/otto/alerts/WatchlistDetector.java
+++ b/src/main/java/otto/alerts/WatchlistDetector.java
@@ -90,10 +90,11 @@ public class WatchlistDetector {
             recommendation = switch (DiffKind.of(event)) {
                 case DROP -> dropped(playerId, player, event.facts());
                 case ADD -> sniped(playerId, player, event.facts());
-                // A trade between two other managers does not change
-                // whether the user can have him: he was unreachable
-                // before and is unreachable now.
-                case TRADE, STATUS -> null;
+                // A player crossing between two other rosters, by trade
+                // or by Commissioner Edit, does not change whether the
+                // user can have him: he was unreachable before and is
+                // unreachable now.
+                case TRADE, COMMISSIONER, STATUS -> null;
             };
             if (recommendation == null) {
                 return Optional.empty();

--- a/src/main/java/otto/events/DiffKind.java
+++ b/src/main/java/otto/events/DiffKind.java
@@ -16,6 +16,12 @@ public enum DiffKind {
 
     STATUS,
     TRADE,
+    /**
+     * A Commissioner Edit that took a player from one roster and put
+     * him on another. It is the same fact a trade records and a
+     * different sentence, because nobody agreed to it.
+     */
+    COMMISSIONER,
     DROP,
     /** A player claimed off free agency: the Snipe, when he is watched. */
     ADD;

--- a/src/main/java/otto/sleeper/SleeperAdapter.java
+++ b/src/main/java/otto/sleeper/SleeperAdapter.java
@@ -11,6 +11,8 @@ import java.util.Map;
 import java.util.Optional;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -28,6 +30,8 @@ import otto.OttoProperties;
  */
 @Component
 public class SleeperAdapter {
+
+    private static final Logger log = LoggerFactory.getLogger(SleeperAdapter.class);
 
     private final SleeperClient client;
     private final SleeperCache cache;
@@ -127,8 +131,18 @@ public class SleeperAdapter {
 
         private static final String TRADE = "trade";
 
+        /**
+         * Sleeper's fourth type, undocumented and live: a commissioner
+         * changing a roster that nobody on it agreed to.
+         */
+        private static final String COMMISSIONER = "commissioner";
+
         public boolean isTrade() {
             return TRADE.equals(type);
+        }
+
+        public boolean isCommissionerEdit() {
+            return COMMISSIONER.equals(type);
         }
 
         /**
@@ -140,6 +154,35 @@ public class SleeperAdapter {
             Map<String, Integer> dropped = new LinkedHashMap<>(drops);
             dropped.keySet().removeAll(adds.keySet());
             return dropped;
+        }
+
+        /**
+         * The players this transaction took straight from one roster and
+         * put on another, read as player id to the roster that gained
+         * them. A trade is the agreed way to do that; a Commissioner
+         * Edit is the other one, and it needs nobody's consent - which
+         * is exactly why a player leaving the user's roster this way is
+         * news.
+         */
+        public Map<String, Integer> crossedRosters() {
+            Map<String, Integer> crossed = new LinkedHashMap<>();
+            adds.forEach((playerId, toRoster) -> {
+                Integer fromRoster = drops.get(playerId);
+                if (fromRoster != null && !fromRoster.equals(toRoster)) {
+                    crossed.put(playerId, toRoster);
+                }
+            });
+            return crossed;
+        }
+
+        /**
+         * The players this transaction put on a roster from free agency:
+         * everyone it added who was on nobody else's roster.
+         */
+        public Map<String, Integer> claimedFromFreeAgency() {
+            Map<String, Integer> claimed = new LinkedHashMap<>(adds);
+            claimed.keySet().removeAll(crossedRosters().keySet());
+            return claimed;
         }
     }
 
@@ -284,9 +327,14 @@ public class SleeperAdapter {
 
     /**
      * The league's transactions for one week: trades, waiver claims,
-     * free agent moves and commissioner edits. Only completed ones are
-     * returned - a pending waiver claim has not happened yet, and a
-     * failed one never will.
+     * free agent moves and commissioner edits. Only transactions whose
+     * status says they happened are returned - {@link TransactionStatus}
+     * holds that rule and the reason each other status is refused.
+     *
+     * A status outside Sleeper's vocabulary is dropped and logged rather
+     * than guessed at. Reading it as news would put a move that may
+     * never have happened in the user's pocket; dropping it in silence
+     * would leave a Sleeper change nobody could find.
      */
     public SourceResult<List<LeagueTransaction>> transactions(String season, int week) {
         String path = leaguePath + "/transactions/" + week;
@@ -300,7 +348,15 @@ public class SleeperAdapter {
                         || !transaction.hasNonNull("type")) {
                     return schemaDrift(path, "transaction_id or type missing");
                 }
-                if (!"complete".equals(transaction.path("status").asText(null))) {
+                String status = transaction.path("status").asText(null);
+                Optional<TransactionStatus> known = TransactionStatus.of(status);
+                if (known.isEmpty()) {
+                    log.warn("Dropping transaction {} on {}: status \"{}\" is outside "
+                                    + "Sleeper's known vocabulary",
+                            transaction.get("transaction_id").asText(), path, status);
+                    continue;
+                }
+                if (!known.get().accepted()) {
                     continue;
                 }
                 // A drifted status_updated must fail loudly. The Alert

--- a/src/main/java/otto/sleeper/TransactionStatus.java
+++ b/src/main/java/otto/sleeper/TransactionStatus.java
@@ -1,0 +1,71 @@
+package otto.sleeper;
+
+import java.util.Locale;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+/**
+ * The statuses Sleeper's transaction vocabulary carries, and which of
+ * them Otto reads as something that happened.
+ *
+ * Only {@link #COMPLETE} is news. Every other status names a
+ * transaction that either has not happened yet or never will, and each
+ * says below why it is refused - so the rule is a stated one rather
+ * than something inferred from the shape of a string comparison.
+ *
+ * A scan of 284,671 live transaction rows saw only {@code complete} and
+ * {@code failed} on the public endpoint; {@code pending} exists in
+ * Sleeper's product but is not served there. The rest are recorded here
+ * anyway, because the vocabulary is Sleeper's and a value it stops
+ * withholding must land on a stated rule rather than on an accident.
+ */
+public enum TransactionStatus {
+
+    /** It happened. This is the only status the Alert path reads. */
+    COMPLETE(true),
+
+    /** An offer nobody has accepted, so no roster has changed. */
+    PROPOSED(false),
+
+    /**
+     * Accepted and inside the commissioner review window. Sleeper's app
+     * shows this state; the documented endpoint does not serve it.
+     */
+    PENDING(false),
+
+    /** Withdrawn before it completed, so no roster has changed. */
+    CANCELLED(false),
+
+    /** A waiver claim that lost, or a move the league refused. It never happened. */
+    FAILED(false),
+
+    /** Turned down by the other side or by the league, so nothing moved. */
+    REJECTED(false);
+
+    private final boolean accepted;
+
+    TransactionStatus(boolean accepted) {
+        this.accepted = accepted;
+    }
+
+    /** True when this status means the transaction actually happened. */
+    public boolean accepted() {
+        return accepted;
+    }
+
+    /**
+     * The status Sleeper published, or empty when it published a value
+     * this vocabulary does not hold. The caller drops an unknown status
+     * and says so out loud: a new Sleeper value must be findable rather
+     * than read as either news or silence.
+     */
+    public static Optional<TransactionStatus> of(String status) {
+        if (status == null) {
+            return Optional.empty();
+        }
+        String normalized = status.trim().toLowerCase(Locale.ROOT);
+        return Stream.of(values())
+                .filter(candidate -> candidate.name().toLowerCase(Locale.ROOT).equals(normalized))
+                .findFirst();
+    }
+}

--- a/src/main/java/otto/snapshot/SnapshotDiffer.java
+++ b/src/main/java/otto/snapshot/SnapshotDiffer.java
@@ -48,6 +48,14 @@ public class SnapshotDiffer {
     /** The fact every Snapshot Diff event carries: what the league was doing. */
     public static final String LEAGUE_STATUS = "leagueStatus";
 
+    /**
+     * The fact an event carries when a Commissioner Edit produced it.
+     * It is what separates a player the user cut from a player taken
+     * off him, which read the same in roster state and mean opposite
+     * things to him.
+     */
+    public static final String BY_COMMISSIONER = "byCommissioner";
+
     public List<Event> diff(Optional<Snapshot> previous, Snapshot current,
             List<SleeperAdapter.LeagueTransaction> transactions, Instant at) {
         if (previous.isEmpty()) {
@@ -62,8 +70,12 @@ public class SnapshotDiffer {
     }
 
     private static Event stamped(Event event, String status) {
+        return withFact(event, LEAGUE_STATUS, status);
+    }
+
+    private static Event withFact(Event event, String name, String value) {
         Map<String, String> facts = new LinkedHashMap<>(event.facts());
-        facts.put(LEAGUE_STATUS, status);
+        facts.put(name, value);
         return new Event(event.key(), event.type(), event.at(), Map.copyOf(facts));
     }
 
@@ -100,10 +112,11 @@ public class SnapshotDiffer {
 
     /**
      * The league activity in the week's transactions: one event per
-     * player a trade moved, one per player claimed off free agency, and
-     * one per player who left a roster and joined nobody else's. A
-     * trade moves every player it names, so a player in both the adds
-     * and the drops was traded, not dropped.
+     * player a trade sent across, one per player a Commissioner Edit
+     * took from one roster and put on another, one per player claimed
+     * off free agency, and one per player who left a roster and joined
+     * nobody else's. A player in both the adds and the drops crossed
+     * rosters, so he was not dropped.
      */
     private List<Event> activityEvents(Snapshot previous, Snapshot current,
             List<SleeperAdapter.LeagueTransaction> transactions, Instant at) {
@@ -114,10 +127,18 @@ public class SnapshotDiffer {
             Instant happenedAt = transaction.statusUpdated();
             if (transaction.isTrade()) {
                 transaction.adds().forEach((playerId, toRoster) ->
-                        events.add(tradeEvent(previous, current, transaction, playerId, toRoster,
-                                happenedAt)));
+                        events.add(crossedRostersEvent(DiffKind.TRADE, previous, current,
+                                transaction, playerId, toRoster, happenedAt)));
                 continue;
             }
+            if (transaction.isCommissionerEdit()) {
+                events.addAll(commissionerEvents(previous, current, transaction, happenedAt));
+                continue;
+            }
+            // A waiver claim and a free agent move add from free agency
+            // and drop to it, and so does a type nobody has seen yet:
+            // reading them by what they did to the rosters is what lets
+            // an unknown type through without a sentence about it.
             transaction.adds().forEach((playerId, toRoster) ->
                     events.add(addEvent(previous, current, transaction, playerId, toRoster,
                             happenedAt)));
@@ -146,12 +167,39 @@ public class SnapshotDiffer {
                 EventType.SNAPSHOT_DIFF, at, Map.copyOf(facts));
     }
 
-    private Event tradeEvent(Snapshot previous, Snapshot current,
+    /**
+     * One Commissioner Edit, read by what it did: players taken from
+     * one roster and put on another, players put on a roster from free
+     * agency, and players cut to free agency. Every event says the
+     * commissioner made it, because that is what tells a detector the
+     * user agreed to none of it.
+     */
+    private List<Event> commissionerEvents(Snapshot previous, Snapshot current,
+            SleeperAdapter.LeagueTransaction transaction, Instant at) {
+        List<Event> events = new ArrayList<>();
+        transaction.crossedRosters().forEach((playerId, toRoster) ->
+                events.add(crossedRostersEvent(DiffKind.COMMISSIONER, previous, current,
+                        transaction, playerId, toRoster, at)));
+        transaction.claimedFromFreeAgency().forEach((playerId, toRoster) ->
+                events.add(addEvent(previous, current, transaction, playerId, toRoster, at)));
+        transaction.droppedToFreeAgency().forEach((playerId, rosterId) ->
+                events.add(dropEvent(previous, current, transaction, playerId, rosterId, at)));
+        return events.stream()
+                .map(event -> withFact(event, BY_COMMISSIONER, "true"))
+                .toList();
+    }
+
+    /**
+     * A player who changed rosters, by trade or by Commissioner Edit.
+     * The two carry the same facts and differ only in how they came
+     * about, which the kind records and the detector reads.
+     */
+    private Event crossedRostersEvent(DiffKind kind, Snapshot previous, Snapshot current,
             SleeperAdapter.LeagueTransaction transaction, String playerId, int toRoster,
             Instant at) {
         Integer fromRoster = transaction.drops().get(playerId);
         Map<String, String> facts = playerFacts(previous, current, playerId);
-        facts.put(DiffKind.factName(), DiffKind.TRADE.fact());
+        facts.put(DiffKind.factName(), kind.fact());
         facts.put("transactionId", transaction.transactionId());
         // Named for the managers rather than "from" and "to": a status
         // event already uses those two for a health designation, and one
@@ -160,8 +208,8 @@ public class SnapshotDiffer {
         facts.put("fromManager", fromRoster == null ? "" : manager(current, fromRoster));
         facts.put("userInvolved", String.valueOf(transaction.rosterIds().stream()
                 .anyMatch(rosterId -> isUser(current, rosterId))));
-        return new Event("snapshot-diff:trade:%s:%s".formatted(
-                transaction.transactionId(), playerId),
+        return new Event("snapshot-diff:%s:%s:%s".formatted(
+                kind.fact(), transaction.transactionId(), playerId),
                 EventType.SNAPSHOT_DIFF, at, Map.copyOf(facts));
     }
 

--- a/src/test/java/otto/LeagueAwarenessScenarioTest.java
+++ b/src/test/java/otto/LeagueAwarenessScenarioTest.java
@@ -3,7 +3,13 @@ package otto;
 import java.time.Duration;
 import java.time.Instant;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import otto.alerts.MuteStore;
@@ -13,6 +19,7 @@ import otto.events.EventType;
 import otto.harness.OutboundStubs;
 import otto.harness.SleeperStubs;
 import otto.harness.WireSeamTest;
+import otto.sleeper.SleeperAdapter;
 import otto.telegram.TelegramWebhook;
 import otto.telegram.WebhookResult;
 
@@ -63,6 +70,8 @@ class LeagueAwarenessScenarioTest extends WireSeamTest {
 
     @Autowired
     private MuteStore muteStore;
+
+    private ListAppender<ILoggingEvent> adapterAppender;
 
     /** A quiet week-14 league with twelve teams and full standings. */
     private void week14League() {
@@ -325,6 +334,188 @@ class LeagueAwarenessScenarioTest extends WireSeamTest {
         telegram.verify(0, postRequestedFor(urlEqualTo(OutboundStubs.SEND_MESSAGE_PATH)));
         assertThat(eventLog.contains("alert:snapshot-diff:drop:1210000000000000004:6813"))
                 .isFalse();
+    }
+
+    /**
+     * A Commissioner Edit takes a player from one roster and puts him
+     * on another without either manager agreeing to anything. Sleeper
+     * does not document the type, but it publishes it, and a player
+     * leaving the user's roster is the loudest news the league can
+     * make.
+     */
+    @Test
+    void aCommissionerEditOffTheUsersRosterIsNews() {
+        week14League();
+        checkRunner.runCheck();
+
+        // The commissioner takes Josh Jacobs off the user's bench and
+        // puts him on GridironGoblin's roster.
+        nextCheckWithNothingElseChanged();
+        SleeperStubs.stubJson(sleeper, SleeperStubs.ROSTERS_PATH,
+                "sleeper/rosters-league-after-commissioner-edit.json", "rosters-v2");
+        SleeperStubs.stubJson(sleeper, TRANSACTIONS_PATH,
+                "sleeper/transactions-week14-commissioner-edit.json", "transactions-v2");
+        checkRunner.runCheck();
+
+        telegram.verify(1, postRequestedFor(urlEqualTo(OutboundStubs.SEND_MESSAGE_PATH)));
+        assertThat(eventLog.contains("alert:commissioner:1210000000000000011")).isTrue();
+        // It is a fact, so it rides at High and states itself - and it
+        // is not called a trade, because nobody traded anything.
+        llm.verify(1, postRequestedFor(urlPathMatching(OutboundStubs.CHAT_COMPLETIONS_PATH))
+                .withRequestBody(containing("Josh Jacobs"))
+                .withRequestBody(containing("SenorMustache"))
+                .withRequestBody(containing("GridironGoblin"))
+                .withRequestBody(containing("Commissioner edit"))
+                .withRequestBody(containing("HIGH")));
+
+        // News once: the next Check says nothing about it.
+        nextCheckWithNothingElseChanged();
+        SleeperStubs.stubNotModified(sleeper, SleeperStubs.ROSTERS_PATH, "rosters-v2");
+        SleeperStubs.stubNotModified(sleeper, TRANSACTIONS_PATH, "transactions-v2");
+        checkRunner.runCheck();
+        telegram.verify(1, postRequestedFor(urlEqualTo(OutboundStubs.SEND_MESSAGE_PATH)));
+    }
+
+    /**
+     * A commissioner drop elsewhere in the league is a drop like any
+     * other: the Notable Player rule decides whether the user hears it.
+     */
+    @Test
+    void aCommissionerDropFollowsTheNotablePlayerRule() {
+        week14League();
+        checkRunner.runCheck();
+
+        nextCheckWithNothingElseChanged();
+        SleeperStubs.stubJson(sleeper, SleeperStubs.ROSTERS_PATH,
+                "sleeper/rosters-league-after-commissioner-drop.json", "rosters-v2");
+        SleeperStubs.stubJson(sleeper, TRANSACTIONS_PATH,
+                "sleeper/transactions-week14-commissioner-drop.json", "transactions-v2");
+        checkRunner.runCheck();
+
+        telegram.verify(1, postRequestedFor(urlEqualTo(OutboundStubs.SEND_MESSAGE_PATH)));
+        assertThat(eventLog.contains("alert:snapshot-diff:drop:1210000000000000012:4866"))
+                .isTrue();
+        llm.verify(1, postRequestedFor(urlPathMatching(OutboundStubs.CHAT_COMPLETIONS_PATH))
+                .withRequestBody(containing("Saquon Barkley"))
+                .withRequestBody(containing("Consider a claim"))
+                .withRequestBody(containing("MEDIUM")));
+    }
+
+    /**
+     * The same edit with nobody on the other end: the commissioner cuts
+     * a player off the user's roster. It reads in roster state exactly
+     * like a cut the user made himself, which is the one the assistant
+     * stays quiet about - so the event has to say who made it.
+     */
+    @Test
+    void aCommissionerCutOffTheUsersRosterIsNewsThoughHisOwnCutIsNot() {
+        week14League();
+        checkRunner.runCheck();
+
+        nextCheckWithNothingElseChanged();
+        SleeperStubs.stubJson(sleeper, SleeperStubs.ROSTERS_PATH,
+                "sleeper/rosters-league-mine-dropped.json", "rosters-v2");
+        SleeperStubs.stubJson(sleeper, TRANSACTIONS_PATH,
+                "sleeper/transactions-week14-commissioner-cut-mine.json", "transactions-v2");
+        checkRunner.runCheck();
+
+        telegram.verify(1, postRequestedFor(urlEqualTo(OutboundStubs.SEND_MESSAGE_PATH)));
+        assertThat(eventLog.contains("alert:snapshot-diff:drop:1210000000000000016:6813"))
+                .isTrue();
+        // He is short a tight end whatever the projection table thinks
+        // of the man: the message states the loss, it does not weigh it.
+        llm.verify(1, postRequestedFor(urlPathMatching(OutboundStubs.CHAT_COMPLETIONS_PATH))
+                .withRequestBody(containing("Dallas Goedert"))
+                .withRequestBody(containing("off your roster"))
+                .withRequestBody(containing("HIGH")));
+    }
+
+    /**
+     * A commissioner add from free agency is a claim like any other:
+     * one add event, which is what a Watchlist Snipe reads. Nobody is
+     * watching Puka Nacua here, so nothing is sent.
+     */
+    @Test
+    void aCommissionerAddFromFreeAgencyIsAnAddLikeAnyOther() {
+        week14League();
+        checkRunner.runCheck();
+
+        nextCheckWithNothingElseChanged();
+        SleeperStubs.stubJson(sleeper, SleeperStubs.ROSTERS_PATH,
+                "sleeper/rosters-league-after-commissioner-add.json", "rosters-v2");
+        SleeperStubs.stubJson(sleeper, TRANSACTIONS_PATH,
+                "sleeper/transactions-week14-commissioner-add.json", "transactions-v2");
+        checkRunner.runCheck();
+
+        assertThat(eventLog.contains("snapshot-diff:add:1210000000000000015:9493")).isTrue();
+        assertThat(eventLog.contains("alert:commissioner:1210000000000000015")).isFalse();
+        telegram.verify(0, postRequestedFor(urlEqualTo(OutboundStubs.SEND_MESSAGE_PATH)));
+    }
+
+    /** A waiver claim that lost is not news: nothing happened. */
+    @Test
+    void aFailedWaiverClaimStaysOutOfTheAlertPath() {
+        week14League();
+        checkRunner.runCheck();
+
+        nextCheckWithNothingElseChanged();
+        SleeperStubs.stubNotModified(sleeper, SleeperStubs.ROSTERS_PATH, "rosters-v1");
+        SleeperStubs.stubJson(sleeper, TRANSACTIONS_PATH,
+                "sleeper/transactions-week14-failed-waiver.json", "transactions-v2");
+        checkRunner.runCheck();
+
+        telegram.verify(0, postRequestedFor(urlEqualTo(OutboundStubs.SEND_MESSAGE_PATH)));
+        assertThat(eventLog.contains("alert:snapshot-diff:drop:1210000000000000014:4866"))
+                .isFalse();
+    }
+
+    /**
+     * A status outside Sleeper's published vocabulary is dropped rather
+     * than read as news, and it is logged, so a value Sleeper starts
+     * serving is findable instead of silent. It costs that one row and
+     * not the read: the same feed carries a completed drop, and that
+     * one still arrives.
+     */
+    @Test
+    void aTransactionWithAnUnknownStatusIsDroppedAndLoggedWithoutLosingTheFeed() {
+        week14League();
+        checkRunner.runCheck();
+
+        ListAppender<ILoggingEvent> log = captureAdapterLog();
+        nextCheckWithNothingElseChanged();
+        SleeperStubs.stubJson(sleeper, SleeperStubs.ROSTERS_PATH,
+                "sleeper/rosters-league-after-commissioner-drop.json", "rosters-v2");
+        SleeperStubs.stubJson(sleeper, TRANSACTIONS_PATH,
+                "sleeper/transactions-week14-unknown-status.json", "transactions-v2");
+        checkRunner.runCheck();
+
+        assertThat(eventLog.contains("alert:trade:1210000000000000013")).isFalse();
+        assertThat(eventLog.contains("alert:snapshot-diff:drop:1210000000000000012:4866"))
+                .isTrue();
+        assertThat(log.list)
+                .anyMatch(entry -> entry.getLevel() == Level.WARN
+                        && entry.getFormattedMessage().contains("reversed")
+                        && entry.getFormattedMessage().contains("1210000000000000013"));
+    }
+
+    /** The adapter's own log, read back for the length of one test. */
+    private ListAppender<ILoggingEvent> captureAdapterLog() {
+        adapterAppender = new ListAppender<>();
+        adapterAppender.start();
+        adapterLog().addAppender(adapterAppender);
+        return adapterAppender;
+    }
+
+    @AfterEach
+    void detachAdapterLog() {
+        if (adapterAppender != null) {
+            adapterLog().detachAppender(adapterAppender);
+            adapterAppender = null;
+        }
+    }
+
+    private static Logger adapterLog() {
+        return (Logger) LoggerFactory.getLogger(SleeperAdapter.class);
     }
 
     @Test

--- a/src/test/resources/fixtures/sleeper/rosters-league-after-commissioner-add.json
+++ b/src/test/resources/fixtures/sleeper/rosters-league-after-commissioner-add.json
@@ -1,0 +1,285 @@
+[
+  {
+    "roster_id": 1,
+    "owner_id": "777001",
+    "league_id": "1389748403805650944",
+    "players": [
+      "4046",
+      "4034",
+      "9509",
+      "6794",
+      "6786",
+      "1466",
+      "8112",
+      "8138",
+      "8135",
+      "5850",
+      "6813"
+    ],
+    "starters": [
+      "4046",
+      "4034",
+      "9509",
+      "6794",
+      "6786",
+      "1466",
+      "8112",
+      "8138",
+      "8135"
+    ],
+    "reserve": [],
+    "settings": {
+      "wins": 9,
+      "losses": 4,
+      "ties": 0,
+      "fpts": 1450,
+      "fpts_decimal": 50,
+      "fpts_against": 1310,
+      "fpts_against_decimal": 25,
+      "waiver_budget_used": 0
+    }
+  },
+  {
+    "roster_id": 2,
+    "owner_id": "777002",
+    "league_id": "1389748403805650944",
+    "players": [
+      "91005",
+      "4866",
+      "92008",
+      "93005",
+      "93009",
+      "94013",
+      "93012",
+      "92015",
+      "91020",
+      "93022",
+      "92025",
+      "9493"
+    ],
+    "starters": [
+      "91005",
+      "4866",
+      "92008",
+      "93005",
+      "93009",
+      "94013",
+      "93012",
+      "92015",
+      "91020"
+    ],
+    "reserve": [],
+    "settings": {
+      "wins": 10,
+      "losses": 3,
+      "ties": 0,
+      "fpts": 1502,
+      "fpts_decimal": 20,
+      "fpts_against": 1288,
+      "fpts_against_decimal": 40,
+      "waiver_budget_used": 0
+    }
+  },
+  {
+    "roster_id": 3,
+    "owner_id": "777003",
+    "league_id": "1389748403805650944",
+    "players": [
+      "91007",
+      "92010",
+      "92012",
+      "93007",
+      "93011",
+      "94006",
+      "93014",
+      "92018",
+      "91011",
+      "94010",
+      "92020"
+    ],
+    "starters": [
+      "91007",
+      "92010",
+      "92012",
+      "93007",
+      "93011",
+      "94006",
+      "93014",
+      "92018",
+      "91011"
+    ],
+    "reserve": [],
+    "settings": {
+      "wins": 9,
+      "losses": 4,
+      "ties": 0,
+      "fpts": 1470,
+      "fpts_decimal": 0,
+      "fpts_against": 1330,
+      "fpts_against_decimal": 10,
+      "waiver_budget_used": 0
+    }
+  },
+  {
+    "roster_id": 4,
+    "owner_id": "777004",
+    "league_id": "1389748403805650944",
+    "players": [],
+    "starters": [],
+    "reserve": [],
+    "settings": {
+      "wins": 8,
+      "losses": 5,
+      "ties": 0,
+      "fpts": 1400,
+      "fpts_decimal": 0,
+      "fpts_against": 1345,
+      "fpts_against_decimal": 0,
+      "waiver_budget_used": 0
+    }
+  },
+  {
+    "roster_id": 5,
+    "owner_id": "777005",
+    "league_id": "1389748403805650944",
+    "players": [],
+    "starters": [],
+    "reserve": [],
+    "settings": {
+      "wins": 8,
+      "losses": 5,
+      "ties": 0,
+      "fpts": 1380,
+      "fpts_decimal": 0,
+      "fpts_against": 1350,
+      "fpts_against_decimal": 0,
+      "waiver_budget_used": 0
+    }
+  },
+  {
+    "roster_id": 6,
+    "owner_id": "777006",
+    "league_id": "1389748403805650944",
+    "players": [],
+    "starters": [],
+    "reserve": [],
+    "settings": {
+      "wins": 7,
+      "losses": 6,
+      "ties": 0,
+      "fpts": 1360,
+      "fpts_decimal": 0,
+      "fpts_against": 1355,
+      "fpts_against_decimal": 0,
+      "waiver_budget_used": 0
+    }
+  },
+  {
+    "roster_id": 7,
+    "owner_id": "777007",
+    "league_id": "1389748403805650944",
+    "players": [],
+    "starters": [],
+    "reserve": [],
+    "settings": {
+      "wins": 7,
+      "losses": 6,
+      "ties": 0,
+      "fpts": 1340,
+      "fpts_decimal": 0,
+      "fpts_against": 1360,
+      "fpts_against_decimal": 0,
+      "waiver_budget_used": 0
+    }
+  },
+  {
+    "roster_id": 8,
+    "owner_id": "777008",
+    "league_id": "1389748403805650944",
+    "players": [],
+    "starters": [],
+    "reserve": [],
+    "settings": {
+      "wins": 6,
+      "losses": 7,
+      "ties": 0,
+      "fpts": 1320,
+      "fpts_decimal": 0,
+      "fpts_against": 1375,
+      "fpts_against_decimal": 0,
+      "waiver_budget_used": 0
+    }
+  },
+  {
+    "roster_id": 9,
+    "owner_id": "777009",
+    "league_id": "1389748403805650944",
+    "players": [],
+    "starters": [],
+    "reserve": [],
+    "settings": {
+      "wins": 5,
+      "losses": 8,
+      "ties": 0,
+      "fpts": 1300,
+      "fpts_decimal": 0,
+      "fpts_against": 1390,
+      "fpts_against_decimal": 0,
+      "waiver_budget_used": 0
+    }
+  },
+  {
+    "roster_id": 10,
+    "owner_id": "777010",
+    "league_id": "1389748403805650944",
+    "players": [],
+    "starters": [],
+    "reserve": [],
+    "settings": {
+      "wins": 4,
+      "losses": 9,
+      "ties": 0,
+      "fpts": 1280,
+      "fpts_decimal": 0,
+      "fpts_against": 1405,
+      "fpts_against_decimal": 0,
+      "waiver_budget_used": 0
+    }
+  },
+  {
+    "roster_id": 11,
+    "owner_id": "777011",
+    "league_id": "1389748403805650944",
+    "players": [],
+    "starters": [],
+    "reserve": [],
+    "settings": {
+      "wins": 3,
+      "losses": 10,
+      "ties": 0,
+      "fpts": 1260,
+      "fpts_decimal": 0,
+      "fpts_against": 1420,
+      "fpts_against_decimal": 0,
+      "waiver_budget_used": 0
+    }
+  },
+  {
+    "roster_id": 12,
+    "owner_id": "777012",
+    "league_id": "1389748403805650944",
+    "players": [],
+    "starters": [],
+    "reserve": [],
+    "settings": {
+      "wins": 2,
+      "losses": 11,
+      "ties": 0,
+      "fpts": 1240,
+      "fpts_decimal": 0,
+      "fpts_against": 1440,
+      "fpts_against_decimal": 0,
+      "waiver_budget_used": 0
+    }
+  }
+]

--- a/src/test/resources/fixtures/sleeper/rosters-league-after-commissioner-drop.json
+++ b/src/test/resources/fixtures/sleeper/rosters-league-after-commissioner-drop.json
@@ -1,0 +1,283 @@
+[
+  {
+    "roster_id": 1,
+    "owner_id": "777001",
+    "league_id": "1389748403805650944",
+    "players": [
+      "4046",
+      "4034",
+      "9509",
+      "6794",
+      "6786",
+      "1466",
+      "8112",
+      "8138",
+      "8135",
+      "5850",
+      "6813"
+    ],
+    "starters": [
+      "4046",
+      "4034",
+      "9509",
+      "6794",
+      "6786",
+      "1466",
+      "8112",
+      "8138",
+      "8135"
+    ],
+    "reserve": [],
+    "settings": {
+      "wins": 9,
+      "losses": 4,
+      "ties": 0,
+      "fpts": 1450,
+      "fpts_decimal": 50,
+      "fpts_against": 1310,
+      "fpts_against_decimal": 25,
+      "waiver_budget_used": 0
+    }
+  },
+  {
+    "roster_id": 2,
+    "owner_id": "777002",
+    "league_id": "1389748403805650944",
+    "players": [
+      "91005",
+      "92008",
+      "93005",
+      "93009",
+      "94013",
+      "93012",
+      "92015",
+      "91020",
+      "93022",
+      "92025"
+    ],
+    "starters": [
+      "91005",
+      "4866",
+      "92008",
+      "93005",
+      "93009",
+      "94013",
+      "93012",
+      "92015",
+      "91020"
+    ],
+    "reserve": [],
+    "settings": {
+      "wins": 10,
+      "losses": 3,
+      "ties": 0,
+      "fpts": 1502,
+      "fpts_decimal": 20,
+      "fpts_against": 1288,
+      "fpts_against_decimal": 40,
+      "waiver_budget_used": 0
+    }
+  },
+  {
+    "roster_id": 3,
+    "owner_id": "777003",
+    "league_id": "1389748403805650944",
+    "players": [
+      "91007",
+      "92010",
+      "92012",
+      "93007",
+      "93011",
+      "94006",
+      "93014",
+      "92018",
+      "91011",
+      "94010",
+      "92020"
+    ],
+    "starters": [
+      "91007",
+      "92010",
+      "92012",
+      "93007",
+      "93011",
+      "94006",
+      "93014",
+      "92018",
+      "91011"
+    ],
+    "reserve": [],
+    "settings": {
+      "wins": 9,
+      "losses": 4,
+      "ties": 0,
+      "fpts": 1470,
+      "fpts_decimal": 0,
+      "fpts_against": 1330,
+      "fpts_against_decimal": 10,
+      "waiver_budget_used": 0
+    }
+  },
+  {
+    "roster_id": 4,
+    "owner_id": "777004",
+    "league_id": "1389748403805650944",
+    "players": [],
+    "starters": [],
+    "reserve": [],
+    "settings": {
+      "wins": 8,
+      "losses": 5,
+      "ties": 0,
+      "fpts": 1400,
+      "fpts_decimal": 0,
+      "fpts_against": 1345,
+      "fpts_against_decimal": 0,
+      "waiver_budget_used": 0
+    }
+  },
+  {
+    "roster_id": 5,
+    "owner_id": "777005",
+    "league_id": "1389748403805650944",
+    "players": [],
+    "starters": [],
+    "reserve": [],
+    "settings": {
+      "wins": 8,
+      "losses": 5,
+      "ties": 0,
+      "fpts": 1380,
+      "fpts_decimal": 0,
+      "fpts_against": 1350,
+      "fpts_against_decimal": 0,
+      "waiver_budget_used": 0
+    }
+  },
+  {
+    "roster_id": 6,
+    "owner_id": "777006",
+    "league_id": "1389748403805650944",
+    "players": [],
+    "starters": [],
+    "reserve": [],
+    "settings": {
+      "wins": 7,
+      "losses": 6,
+      "ties": 0,
+      "fpts": 1360,
+      "fpts_decimal": 0,
+      "fpts_against": 1355,
+      "fpts_against_decimal": 0,
+      "waiver_budget_used": 0
+    }
+  },
+  {
+    "roster_id": 7,
+    "owner_id": "777007",
+    "league_id": "1389748403805650944",
+    "players": [],
+    "starters": [],
+    "reserve": [],
+    "settings": {
+      "wins": 7,
+      "losses": 6,
+      "ties": 0,
+      "fpts": 1340,
+      "fpts_decimal": 0,
+      "fpts_against": 1360,
+      "fpts_against_decimal": 0,
+      "waiver_budget_used": 0
+    }
+  },
+  {
+    "roster_id": 8,
+    "owner_id": "777008",
+    "league_id": "1389748403805650944",
+    "players": [],
+    "starters": [],
+    "reserve": [],
+    "settings": {
+      "wins": 6,
+      "losses": 7,
+      "ties": 0,
+      "fpts": 1320,
+      "fpts_decimal": 0,
+      "fpts_against": 1375,
+      "fpts_against_decimal": 0,
+      "waiver_budget_used": 0
+    }
+  },
+  {
+    "roster_id": 9,
+    "owner_id": "777009",
+    "league_id": "1389748403805650944",
+    "players": [],
+    "starters": [],
+    "reserve": [],
+    "settings": {
+      "wins": 5,
+      "losses": 8,
+      "ties": 0,
+      "fpts": 1300,
+      "fpts_decimal": 0,
+      "fpts_against": 1390,
+      "fpts_against_decimal": 0,
+      "waiver_budget_used": 0
+    }
+  },
+  {
+    "roster_id": 10,
+    "owner_id": "777010",
+    "league_id": "1389748403805650944",
+    "players": [],
+    "starters": [],
+    "reserve": [],
+    "settings": {
+      "wins": 4,
+      "losses": 9,
+      "ties": 0,
+      "fpts": 1280,
+      "fpts_decimal": 0,
+      "fpts_against": 1405,
+      "fpts_against_decimal": 0,
+      "waiver_budget_used": 0
+    }
+  },
+  {
+    "roster_id": 11,
+    "owner_id": "777011",
+    "league_id": "1389748403805650944",
+    "players": [],
+    "starters": [],
+    "reserve": [],
+    "settings": {
+      "wins": 3,
+      "losses": 10,
+      "ties": 0,
+      "fpts": 1260,
+      "fpts_decimal": 0,
+      "fpts_against": 1420,
+      "fpts_against_decimal": 0,
+      "waiver_budget_used": 0
+    }
+  },
+  {
+    "roster_id": 12,
+    "owner_id": "777012",
+    "league_id": "1389748403805650944",
+    "players": [],
+    "starters": [],
+    "reserve": [],
+    "settings": {
+      "wins": 2,
+      "losses": 11,
+      "ties": 0,
+      "fpts": 1240,
+      "fpts_decimal": 0,
+      "fpts_against": 1440,
+      "fpts_against_decimal": 0,
+      "waiver_budget_used": 0
+    }
+  }
+]

--- a/src/test/resources/fixtures/sleeper/rosters-league-after-commissioner-edit.json
+++ b/src/test/resources/fixtures/sleeper/rosters-league-after-commissioner-edit.json
@@ -1,0 +1,284 @@
+[
+  {
+    "roster_id": 1,
+    "owner_id": "777001",
+    "league_id": "1389748403805650944",
+    "players": [
+      "4046",
+      "4034",
+      "9509",
+      "6794",
+      "6786",
+      "1466",
+      "8112",
+      "8138",
+      "8135",
+      "6813"
+    ],
+    "starters": [
+      "4046",
+      "4034",
+      "9509",
+      "6794",
+      "6786",
+      "1466",
+      "8112",
+      "8138",
+      "8135"
+    ],
+    "reserve": [],
+    "settings": {
+      "wins": 9,
+      "losses": 4,
+      "ties": 0,
+      "fpts": 1450,
+      "fpts_decimal": 50,
+      "fpts_against": 1310,
+      "fpts_against_decimal": 25,
+      "waiver_budget_used": 0
+    }
+  },
+  {
+    "roster_id": 2,
+    "owner_id": "777002",
+    "league_id": "1389748403805650944",
+    "players": [
+      "91005",
+      "4866",
+      "92008",
+      "93005",
+      "93009",
+      "94013",
+      "93012",
+      "92015",
+      "91020",
+      "93022",
+      "92025",
+      "5850"
+    ],
+    "starters": [
+      "91005",
+      "4866",
+      "92008",
+      "93005",
+      "93009",
+      "94013",
+      "93012",
+      "92015",
+      "91020"
+    ],
+    "reserve": [],
+    "settings": {
+      "wins": 10,
+      "losses": 3,
+      "ties": 0,
+      "fpts": 1502,
+      "fpts_decimal": 20,
+      "fpts_against": 1288,
+      "fpts_against_decimal": 40,
+      "waiver_budget_used": 0
+    }
+  },
+  {
+    "roster_id": 3,
+    "owner_id": "777003",
+    "league_id": "1389748403805650944",
+    "players": [
+      "91007",
+      "92010",
+      "92012",
+      "93007",
+      "93011",
+      "94006",
+      "93014",
+      "92018",
+      "91011",
+      "94010",
+      "92020"
+    ],
+    "starters": [
+      "91007",
+      "92010",
+      "92012",
+      "93007",
+      "93011",
+      "94006",
+      "93014",
+      "92018",
+      "91011"
+    ],
+    "reserve": [],
+    "settings": {
+      "wins": 9,
+      "losses": 4,
+      "ties": 0,
+      "fpts": 1470,
+      "fpts_decimal": 0,
+      "fpts_against": 1330,
+      "fpts_against_decimal": 10,
+      "waiver_budget_used": 0
+    }
+  },
+  {
+    "roster_id": 4,
+    "owner_id": "777004",
+    "league_id": "1389748403805650944",
+    "players": [],
+    "starters": [],
+    "reserve": [],
+    "settings": {
+      "wins": 8,
+      "losses": 5,
+      "ties": 0,
+      "fpts": 1400,
+      "fpts_decimal": 0,
+      "fpts_against": 1345,
+      "fpts_against_decimal": 0,
+      "waiver_budget_used": 0
+    }
+  },
+  {
+    "roster_id": 5,
+    "owner_id": "777005",
+    "league_id": "1389748403805650944",
+    "players": [],
+    "starters": [],
+    "reserve": [],
+    "settings": {
+      "wins": 8,
+      "losses": 5,
+      "ties": 0,
+      "fpts": 1380,
+      "fpts_decimal": 0,
+      "fpts_against": 1350,
+      "fpts_against_decimal": 0,
+      "waiver_budget_used": 0
+    }
+  },
+  {
+    "roster_id": 6,
+    "owner_id": "777006",
+    "league_id": "1389748403805650944",
+    "players": [],
+    "starters": [],
+    "reserve": [],
+    "settings": {
+      "wins": 7,
+      "losses": 6,
+      "ties": 0,
+      "fpts": 1360,
+      "fpts_decimal": 0,
+      "fpts_against": 1355,
+      "fpts_against_decimal": 0,
+      "waiver_budget_used": 0
+    }
+  },
+  {
+    "roster_id": 7,
+    "owner_id": "777007",
+    "league_id": "1389748403805650944",
+    "players": [],
+    "starters": [],
+    "reserve": [],
+    "settings": {
+      "wins": 7,
+      "losses": 6,
+      "ties": 0,
+      "fpts": 1340,
+      "fpts_decimal": 0,
+      "fpts_against": 1360,
+      "fpts_against_decimal": 0,
+      "waiver_budget_used": 0
+    }
+  },
+  {
+    "roster_id": 8,
+    "owner_id": "777008",
+    "league_id": "1389748403805650944",
+    "players": [],
+    "starters": [],
+    "reserve": [],
+    "settings": {
+      "wins": 6,
+      "losses": 7,
+      "ties": 0,
+      "fpts": 1320,
+      "fpts_decimal": 0,
+      "fpts_against": 1375,
+      "fpts_against_decimal": 0,
+      "waiver_budget_used": 0
+    }
+  },
+  {
+    "roster_id": 9,
+    "owner_id": "777009",
+    "league_id": "1389748403805650944",
+    "players": [],
+    "starters": [],
+    "reserve": [],
+    "settings": {
+      "wins": 5,
+      "losses": 8,
+      "ties": 0,
+      "fpts": 1300,
+      "fpts_decimal": 0,
+      "fpts_against": 1390,
+      "fpts_against_decimal": 0,
+      "waiver_budget_used": 0
+    }
+  },
+  {
+    "roster_id": 10,
+    "owner_id": "777010",
+    "league_id": "1389748403805650944",
+    "players": [],
+    "starters": [],
+    "reserve": [],
+    "settings": {
+      "wins": 4,
+      "losses": 9,
+      "ties": 0,
+      "fpts": 1280,
+      "fpts_decimal": 0,
+      "fpts_against": 1405,
+      "fpts_against_decimal": 0,
+      "waiver_budget_used": 0
+    }
+  },
+  {
+    "roster_id": 11,
+    "owner_id": "777011",
+    "league_id": "1389748403805650944",
+    "players": [],
+    "starters": [],
+    "reserve": [],
+    "settings": {
+      "wins": 3,
+      "losses": 10,
+      "ties": 0,
+      "fpts": 1260,
+      "fpts_decimal": 0,
+      "fpts_against": 1420,
+      "fpts_against_decimal": 0,
+      "waiver_budget_used": 0
+    }
+  },
+  {
+    "roster_id": 12,
+    "owner_id": "777012",
+    "league_id": "1389748403805650944",
+    "players": [],
+    "starters": [],
+    "reserve": [],
+    "settings": {
+      "wins": 2,
+      "losses": 11,
+      "ties": 0,
+      "fpts": 1240,
+      "fpts_decimal": 0,
+      "fpts_against": 1440,
+      "fpts_against_decimal": 0,
+      "waiver_budget_used": 0
+    }
+  }
+]

--- a/src/test/resources/fixtures/sleeper/transactions-week14-commissioner-add.json
+++ b/src/test/resources/fixtures/sleeper/transactions-week14-commissioner-add.json
@@ -1,0 +1,21 @@
+[
+  {
+    "type": "commissioner",
+    "transaction_id": "1210000000000000015",
+    "status": "complete",
+    "status_updated": 1796752800000,
+    "created": 1796752800000,
+    "roster_ids": [
+      2
+    ],
+    "consenter_ids": [
+      2
+    ],
+    "adds": {
+      "9493": 2
+    },
+    "drops": null,
+    "draft_picks": [],
+    "waiver_budget": []
+  }
+]

--- a/src/test/resources/fixtures/sleeper/transactions-week14-commissioner-cut-mine.json
+++ b/src/test/resources/fixtures/sleeper/transactions-week14-commissioner-cut-mine.json
@@ -1,0 +1,21 @@
+[
+  {
+    "type": "commissioner",
+    "transaction_id": "1210000000000000016",
+    "status": "complete",
+    "status_updated": 1796752800000,
+    "created": 1796752800000,
+    "roster_ids": [
+      1
+    ],
+    "consenter_ids": [
+      1
+    ],
+    "adds": null,
+    "drops": {
+      "6813": 1
+    },
+    "draft_picks": [],
+    "waiver_budget": []
+  }
+]

--- a/src/test/resources/fixtures/sleeper/transactions-week14-commissioner-drop.json
+++ b/src/test/resources/fixtures/sleeper/transactions-week14-commissioner-drop.json
@@ -1,0 +1,21 @@
+[
+  {
+    "type": "commissioner",
+    "transaction_id": "1210000000000000012",
+    "status": "complete",
+    "status_updated": 1796752800000,
+    "created": 1796752800000,
+    "roster_ids": [
+      2
+    ],
+    "consenter_ids": [
+      2
+    ],
+    "adds": null,
+    "drops": {
+      "4866": 2
+    },
+    "draft_picks": [],
+    "waiver_budget": []
+  }
+]

--- a/src/test/resources/fixtures/sleeper/transactions-week14-commissioner-edit.json
+++ b/src/test/resources/fixtures/sleeper/transactions-week14-commissioner-edit.json
@@ -1,0 +1,24 @@
+[
+  {
+    "type": "commissioner",
+    "transaction_id": "1210000000000000011",
+    "status": "complete",
+    "status_updated": 1796752800000,
+    "created": 1796752800000,
+    "roster_ids": [
+      1,
+      2
+    ],
+    "consenter_ids": [
+      1
+    ],
+    "adds": {
+      "5850": 2
+    },
+    "drops": {
+      "5850": 1
+    },
+    "draft_picks": [],
+    "waiver_budget": []
+  }
+]

--- a/src/test/resources/fixtures/sleeper/transactions-week14-failed-waiver.json
+++ b/src/test/resources/fixtures/sleeper/transactions-week14-failed-waiver.json
@@ -1,0 +1,23 @@
+[
+  {
+    "type": "waiver",
+    "transaction_id": "1210000000000000014",
+    "status": "failed",
+    "status_updated": 1796752800000,
+    "created": 1796752800000,
+    "roster_ids": [
+      2
+    ],
+    "consenter_ids": [
+      2
+    ],
+    "adds": {
+      "9493": 2
+    },
+    "drops": {
+      "4866": 2
+    },
+    "draft_picks": [],
+    "waiver_budget": []
+  }
+]

--- a/src/test/resources/fixtures/sleeper/transactions-week14-unknown-status.json
+++ b/src/test/resources/fixtures/sleeper/transactions-week14-unknown-status.json
@@ -1,0 +1,46 @@
+[
+  {
+    "type": "trade",
+    "transaction_id": "1210000000000000013",
+    "status": "reversed",
+    "status_updated": 1796752800000,
+    "created": 1796752800000,
+    "roster_ids": [
+      2,
+      3
+    ],
+    "consenter_ids": [
+      2,
+      3
+    ],
+    "adds": {
+      "4866": 3,
+      "92010": 2
+    },
+    "drops": {
+      "4866": 2,
+      "92010": 3
+    },
+    "draft_picks": [],
+    "waiver_budget": []
+  },
+  {
+    "type": "commissioner",
+    "transaction_id": "1210000000000000012",
+    "status": "complete",
+    "status_updated": 1796752800000,
+    "created": 1796752800000,
+    "roster_ids": [
+      2
+    ],
+    "consenter_ids": [
+      2
+    ],
+    "adds": null,
+    "drops": {
+      "4866": 2
+    },
+    "draft_picks": [],
+    "waiver_budget": []
+  }
+]


### PR DESCRIPTION
## Why

Closes #39.

Sleeper names five transaction types and serves four; Otto handled three. A live scan of 284,671 rows found 6,377 `commissioner` rows. The commissioner can take a player off a roster with nobody's consent, and Otto said nothing about it.

The status filter had the same shape of problem. `SleeperAdapter` kept only `complete` rows because of the way one line was written, not because a rule said so. A new Sleeper status would have changed the behaviour in silence.

## What changed

**Commissioner Edits are read.** A Commissioner Edit that sends a player to another roster now produces the per-player Snapshot Diff events a trade does, and one High-confidence Alert that says "Commissioner edit" rather than naming an agreement that never happened. It rides the League Activity trigger and the trade mute class: it is the news the user opted into when he asked to hear about players changing hands. A Commissioner Edit that adds from free agency, or cuts to it, stays an ordinary add or drop and follows the Notable Player rule.

**A commissioner cut off the user's roster is no longer swallowed.** It reads in roster state exactly like a cut he made himself, which the detector filters out as his own decision. Every event a Commissioner Edit produces now carries `byCommissioner`, and the filter reads it: his own cut stays quiet, the commissioner's cut sends and names the slot it opened. This was found in review, not in the original ticket.

**The status filter is a stated rule.** `TransactionStatus` holds Sleeper's whole vocabulary - `complete`, `proposed`, `pending`, `cancelled`, `failed`, `rejected` - accepts only `complete`, and says on each of the others why it is refused. A status outside the vocabulary costs that one row and not the read, and it is logged with its transaction id, so a new Sleeper value is findable instead of silent.

An unknown transaction type, such as the unobserved `chopped`, keeps the generic add and drop path. Nothing prints "the commissioner made it" about an actor nobody has seen act.

## Docs

ADR-0004 is amended with the status vocabulary, the evidence that `pending` is not served on the documented endpoint, and both decisions above.

## Testing

Six new wire-seam tests in `LeagueAwarenessScenarioTest`: a commissioner edit across rosters, a commissioner cut off the user's roster, a commissioner add from free agency, a failed waiver, and an unknown status that proves the completed row in the same feed still arrives.

`mvn test`: 206 tests, 0 failures.

## Note for the reviewer

A Commissioner Edit between two other rosters alerts unconditionally rather than through the Notable Player cutoffs. That matches how a trade between two other managers behaves - the cutoffs answer "is this man worth a claim", and nobody can claim a player who is already on another roster. The ADR states it.
