### PR TITLE
chore: deploy on merge, so main and production cannot drift

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,94 @@
+name: Build and deploy
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+# One deploy at a time. Two merges landing close together would
+# otherwise race to publish versions and move the "live" alias, and the
+# loser would leave the alias pointing at the older of the two.
+# Pull requests only build, so cancelling a superseded one costs
+# nothing; a deploy is never cancelled halfway.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build and test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '25'
+          cache: maven
+
+      - name: Build the Lambda zip, and run the app's tests
+        run: mvn -B -ntp package
+
+      - name: Read the stack's promises back off the template
+        run: mvn -B -ntp test -f infra/pom.xml
+
+      # The deploy job installs this zip rather than building its own.
+      # A rebuild would be a different artifact from the one the tests
+      # just passed against, which is the whole thing this is avoiding.
+      - uses: actions/upload-artifact@v7
+        with:
+          name: lambda-zip
+          path: target/otto-lambda.zip
+          retention-days: 7
+          if-no-files-found: error
+
+  deploy:
+    name: Deploy
+    needs: build
+    if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # Lets the runner mint the OIDC token that AWS trades for
+      # credentials. Without it there is no token and no way in.
+      id-token: write
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '25'
+          cache: maven
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: '24'
+
+      # "cdk synth" reads this path as ../target/otto-lambda.zip.
+      - uses: actions/download-artifact@v8
+        with:
+          name: lambda-zip
+          path: target
+
+      - uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
+          aws-region: us-east-1
+
+      # OttoStack by name, never --all: OttoDeployRoleStack holds this
+      # workflow's own permissions, and a pipeline that could deploy it
+      # could widen what it is allowed to do.
+      - name: Deploy OttoStack
+        working-directory: infra
+        env:
+          ALERT_EMAIL: ${{ secrets.ALERT_EMAIL }}
+        run: |
+          npx --yes aws-cdk@2 deploy OttoStack \
+            -c "alertEmail=$ALERT_EMAIL" \
+            --require-approval never

--- a/docs/adr/0009-deploy-on-merge.md
+++ b/docs/adr/0009-deploy-on-merge.md
@@ -1,0 +1,92 @@
+# ADR-0009: Merging to main is what deploys
+
+Status: accepted (2026-08-20, issue #49)
+
+ADR-0008 put the assistant on AWS and left the deploy to a person
+typing `mvn package` and `cdk deploy`. This ADR records why that step
+moved into GitHub Actions, and what the pipeline is allowed to do.
+
+## What the manual deploy actually cost
+
+On 2026-08-20 production was found running the build from 2026-08-13.
+Two fixes had been merged and reviewed in between, and neither was
+running. One of them was the preseason fix, so for a week the deployed
+assistant read the wrong season's nflverse file while `main` held the
+code that read the right one.
+
+Nothing was broken in a way anyone could see. The heartbeat was
+healthy, no alarm fired, and the repository looked correct. A merged
+fix that is not deployed is indistinguishable from a fix that does not
+work, and the assistant has no way to report the difference. That is
+the failure this closes: not slow deploys, but silent ones.
+
+## The pipeline is the build that already existed
+
+One workflow. A pull request builds the zip, runs the app's tests and
+runs the infra template assertions. A push to `main` does the same and
+then deploys `OttoStack`.
+
+The deploy installs the artifact the build produced rather than
+building its own. Two `mvn package` runs of the same commit are close
+enough to identical for most purposes and are not the same bytes, and
+the point of testing an artifact is to ship that artifact.
+
+Deploys are serialized. Two merges landing a minute apart would
+otherwise both publish versions and both move the `live` alias, and the
+alias would end up wherever the slower one finished - which is not
+necessarily the newer commit.
+
+There is no approval gate between a merge and a deploy. One user, one
+league, and a review already happened on the pull request; a second
+button to press is the same manual step this ADR removes, wearing a
+different hat. What makes it safe to skip is that the rollback is
+`cdk deploy` of an older commit, and the heartbeat and error alarms
+already say when the deployed thing is wrong.
+
+## The pipeline holds no AWS key
+
+The repository is public. Anyone can open a pull request against it,
+and a workflow that held a stored access key would be one
+`pull_request_target` mistake away from handing that key out.
+
+So there is no key. GitHub mints a short-lived OIDC token for a
+workflow run, AWS trades it for session credentials, and the role's
+trust policy names exactly one repository and one branch:
+`repo:brandon-sanchez/Otto:ref:refs/heads/main`, matched with
+StringEquals. The wildcard version of that condition is the standard
+way this is got wrong - `repo:owner/Otto:*` also matches a pull request
+branch pushed by a stranger.
+
+The role carries no permissions of its own. It may assume the three CDK
+bootstrap roles - lookup, file-publishing, deploy - and nothing else.
+Those roles already scope what a CDK deploy may touch, so restating
+that scope on the pipeline role would only create a second copy to
+drift. The fourth bootstrap role, `cfn-exec`, is deliberately not
+granted: CloudFormation assumes it, the CLI does not, and it is the one
+that can create anything in the account.
+
+## The role lives in a stack the pipeline cannot deploy
+
+`DeployRoleStack` is separate from `OttoStack`, and the workflow
+deploys `OttoStack` by name rather than `--all`. So the pipeline never
+holds the template that defines its own permissions, and widening the
+deploy role takes a human at a terminal rather than a commit landing on
+main.
+
+The cost is that a bare `cdk deploy` no longer works - CDK refuses when
+an app has more than one stack and asks which. That refusal is the
+feature.
+
+## What the pipeline deliberately does not contain
+
+- **A staging deploy** - ADR-0008 ruled out a dev stage, and a pipeline
+  is not a reason to reopen it.
+- **A manual approval step** - see above; it is the manual deploy again.
+- **A release tag or a version number** - the commit on `main` is the
+  version, and CloudFormation already keeps the previous template.
+- **A rollback job** - rolling back is deploying an older commit, which
+  is the same path as any other deploy and stays tested for that reason.
+
+`DeployRoleStackTest` asserts the trust condition, the three assumable
+roles and the absence of a wildcard, because each of those is a way the
+pipeline could quietly become someone else's.

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -1,6 +1,12 @@
 # Deploy
 
-One CDK stack deploys the whole assistant to `us-east-1`.
+GitHub Actions deploys the assistant to `us-east-1` on every push to
+`main`. This page is the setup that happens once, and the manual path
+for when you need it.
+
+The CDK app holds two stacks, so every command names the one it means.
+`OttoStack` is the assistant, and Actions deploys it. `OttoDeployRoleStack`
+is the role Actions deploys as, and only a human deploys that.
 
 You need the AWS CLI signed in, Node, JDK 25 and Maven.
 
@@ -32,7 +38,7 @@ without it.
 mvn package                                          # builds the Lambda zip
 cd infra
 npx aws-cdk@2 bootstrap aws://ACCOUNT_ID/us-east-1   # once per account
-npx aws-cdk@2 deploy -c alertEmail=you@example.com
+npx aws-cdk@2 deploy OttoStack -c alertEmail=you@example.com
 ```
 
 `alertEmail` is required and the stack will not synthesize without it.
@@ -47,7 +53,27 @@ a reservation that would leave fewer than 10 unreserved - so none can be
 made. Request a quota increase for Lambda concurrent executions, then
 redeploy without the flag to limit the Check to one run at a time.
 
-## 3. Point Telegram at the webhook
+## 3. Hand the deploys to GitHub Actions
+
+Once, so the workflow can reach AWS without a stored key. `alertEmail`
+is needed here too, because the app synthesizes both stacks.
+
+```sh
+npx aws-cdk@2 deploy OttoDeployRoleStack -c alertEmail=you@example.com
+```
+
+It prints `DeployRoleArn`. Give the workflow that and the same address:
+
+```sh
+gh secret set AWS_DEPLOY_ROLE_ARN --body "$DEPLOY_ROLE_ARN"
+gh secret set ALERT_EMAIL --body 'you@example.com'
+```
+
+The role trusts one repository and one branch. Renaming either, or
+moving the repo, means editing `SUBJECT` in `DeployRoleStack` and
+deploying it again by hand.
+
+## 4. Point Telegram at the webhook
 
 The deploy prints `WebhookUrl`.
 
@@ -62,7 +88,7 @@ Telegram delivers to a webhook or to `getUpdates`, never both, so this
 stops a local run from reading messages. To go back to running locally,
 call `deleteWebhook`.
 
-## 4. Check it works
+## 5. Check it works
 
 - **The Check loop.** Tail the scheduled function's log group.
   `heartbeat check-completed` should appear once a minute.

--- a/infra/src/main/java/otto/infra/DeployRoleStack.java
+++ b/infra/src/main/java/otto/infra/DeployRoleStack.java
@@ -1,0 +1,124 @@
+package otto.infra;
+
+import java.util.List;
+import java.util.Map;
+
+import software.amazon.awscdk.CfnOutput;
+import software.amazon.awscdk.Stack;
+import software.amazon.awscdk.StackProps;
+import software.amazon.awscdk.services.iam.CfnOIDCProvider;
+import software.amazon.awscdk.services.iam.Effect;
+import software.amazon.awscdk.services.iam.FederatedPrincipal;
+import software.amazon.awscdk.services.iam.PolicyStatement;
+import software.amazon.awscdk.services.iam.Role;
+import software.constructs.Construct;
+
+/**
+ * The identity GitHub Actions deploys as.
+ *
+ * <p>This is its own stack, and not part of {@link OttoStack}, because
+ * of what the split buys. The workflow deploys {@code OttoStack} by
+ * name, so it never holds the template that defines its own
+ * permissions: widening the deploy role has to be a human running
+ * {@code cdk deploy} locally, not a commit landing on main. The two
+ * also live on different clocks - the assistant changes weekly and
+ * this changes about never.
+ *
+ * <p>There are no access keys anywhere. GitHub mints a short-lived
+ * OIDC token for a workflow run, AWS trades it for session
+ * credentials, and the trust policy pins who may make that trade. The
+ * repository is public, so anyone can open a pull request against it;
+ * the subject condition is what stops a fork or a branch from
+ * borrowing the deploy role, and it is the only thing that does.
+ */
+public class DeployRoleStack extends Stack {
+
+    private static final String OIDC_URL = "https://token.actions.githubusercontent.com";
+
+    /**
+     * The audience the workflow requests. AWS rejects a token minted
+     * for anyone else, which is what stops a token issued for some
+     * other cloud from being replayed here.
+     */
+    private static final String AUDIENCE = "sts.amazonaws.com";
+
+    /**
+     * Exactly one repository and exactly one branch may assume the
+     * role, matched with StringEquals rather than StringLike. A
+     * wildcard here is the standard way this goes wrong: {@code
+     * repo:owner/Otto:*} would also match every pull request branch,
+     * including one opened from a fork by a stranger.
+     */
+    private static final String SUBJECT = "repo:brandon-sanchez/Otto:ref:refs/heads/main";
+
+    /**
+     * The qualifier CDK bootstrapped this account with - the {@code
+     * hnb659fds} in every bootstrap role name. It is the default, and
+     * it is spelled here because the role has to name the exact roles
+     * it may assume. Re-bootstrapping under a custom qualifier means
+     * changing this.
+     */
+    private static final String QUALIFIER = "hnb659fds";
+
+    /**
+     * The three roles the CDK CLI assumes on a deploy: one to read
+     * context, one to upload the asset, one to drive CloudFormation.
+     * The fourth bootstrap role, {@code cfn-exec}, is assumed by
+     * CloudFormation itself rather than by the CLI, so it is not
+     * granted here.
+     */
+    private static final List<String> BOOTSTRAP_ROLES =
+            List.of("lookup", "file-publishing", "deploy");
+
+    /**
+     * Fixed, so the workflow's role ARN survives a redeploy of this
+     * stack. A generated name would change and silently break the
+     * pipeline.
+     */
+    private static final String ROLE_NAME = "otto-github-deploy";
+
+    public DeployRoleStack(Construct scope, String id, StackProps props) {
+        super(scope, id, props);
+
+        CfnOIDCProvider github = CfnOIDCProvider.Builder.create(this, "GithubOidc")
+                .url(OIDC_URL)
+                // No thumbprint list. IAM retrieves the provider's
+                // intermediate CA thumbprint itself, so pinning one
+                // here would only be a value that expires one day and
+                // fails a deploy for a reason nobody remembers.
+                .clientIdList(List.of(AUDIENCE))
+                .build();
+
+        Role deployer = Role.Builder.create(this, "GithubDeployRole")
+                .roleName(ROLE_NAME)
+                .description("Assumed by GitHub Actions on a push to main, to deploy OttoStack")
+                .assumedBy(new FederatedPrincipal(
+                        github.getAttrArn(),
+                        Map.of("StringEquals", Map.of(
+                                "token.actions.githubusercontent.com:aud", AUDIENCE,
+                                "token.actions.githubusercontent.com:sub", SUBJECT)),
+                        "sts:AssumeRoleWithWebIdentity"))
+                .build();
+
+        // The role carries no AWS permissions of its own. Everything a
+        // deploy does, it does through the bootstrap roles, which
+        // already scope what a CDK deploy is allowed to touch - so
+        // there is no second, drifting copy of that list to maintain.
+        deployer.addToPolicy(PolicyStatement.Builder.create()
+                .effect(Effect.ALLOW)
+                .actions(List.of("sts:AssumeRole"))
+                .resources(BOOTSTRAP_ROLES.stream().map(this::bootstrapRoleArn).toList())
+                .build());
+
+        CfnOutput.Builder.create(this, "DeployRoleArn")
+                .value(deployer.getRoleArn())
+                .description("Set this as the AWS_DEPLOY_ROLE_ARN repository secret")
+                .build();
+    }
+
+    private String bootstrapRoleArn(String role) {
+        return "arn:%s:iam::%s:role/cdk-%s-%s-role-%s-%s"
+                .formatted(getPartition(), getAccount(), QUALIFIER, role,
+                        getAccount(), getRegion());
+    }
+}

--- a/infra/src/main/java/otto/infra/OttoApp.java
+++ b/infra/src/main/java/otto/infra/OttoApp.java
@@ -5,9 +5,17 @@ import software.amazon.awscdk.Environment;
 import software.amazon.awscdk.StackProps;
 
 /**
- * The CDK entry point. One app, one stack, one region: the assistant
- * serves one league for one user, and a second stage would be a second
- * thing to keep alive for no one's benefit.
+ * The CDK entry point. One stage, one region: the assistant serves one
+ * league for one user, and a dev stage would be a second thing to keep
+ * alive for no one's benefit.
+ *
+ * <p>Two stacks share that stage, and the split is about who deploys
+ * them rather than about size. {@link OttoStack} is the assistant, and
+ * GitHub Actions deploys it on every push to main. {@link
+ * DeployRoleStack} is the identity Actions deploys as, and a human
+ * deploys it by hand, so that a commit cannot change what the pipeline
+ * is allowed to do. Because they are named stacks in one app, a bare
+ * "cdk deploy" now refuses and asks which - that refusal is the point.
  */
 public final class OttoApp {
 
@@ -23,13 +31,20 @@ public final class OttoApp {
 
     public static void main(String[] args) {
         App app = new App();
-        new OttoStack(app, "OttoStack", StackProps.builder()
-                .description("Otto, the fantasy football assistant")
+        new OttoStack(app, "OttoStack",
+                props("Otto, the fantasy football assistant"));
+        new DeployRoleStack(app, "OttoDeployRoleStack",
+                props("The role GitHub Actions deploys Otto as"));
+        app.synth();
+    }
+
+    private static StackProps props(String description) {
+        return StackProps.builder()
+                .description(description)
                 .env(Environment.builder()
                         .account(System.getenv("CDK_DEFAULT_ACCOUNT"))
                         .region(REGION)
                         .build())
-                .build());
-        app.synth();
+                .build();
     }
 }

--- a/infra/src/test/java/otto/infra/DeployRoleStackTest.java
+++ b/infra/src/test/java/otto/infra/DeployRoleStackTest.java
@@ -1,0 +1,160 @@
+package otto.infra;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import software.amazon.awscdk.App;
+import software.amazon.awscdk.Environment;
+import software.amazon.awscdk.StackProps;
+import software.amazon.awscdk.assertions.Match;
+import software.amazon.awscdk.assertions.Template;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * What the deploy identity promises, read back off the template. Every
+ * assertion here is a way the pipeline could be handed to someone it
+ * was not meant for, so each one is worth a test rather than a review.
+ */
+class DeployRoleStackTest {
+
+    private static final String ACCOUNT = "111111111111";
+
+    private static Template template;
+
+    @BeforeAll
+    static void synth() {
+        template = Template.fromStack(new DeployRoleStack(new App(), "OttoDeployRoleStack",
+                StackProps.builder()
+                        .env(Environment.builder()
+                                .account(ACCOUNT)
+                                .region("us-east-1")
+                                .build())
+                        .build()));
+    }
+
+    @Test
+    void githubIsTheOnlyIdentityProviderAndItsTokensMustNameAws() {
+        template.resourceCountIs("AWS::IAM::OIDCProvider", 1);
+        template.hasResourceProperties("AWS::IAM::OIDCProvider", Map.of(
+                "Url", "https://token.actions.githubusercontent.com",
+                "ClientIdList", List.of("sts.amazonaws.com")));
+    }
+
+    /**
+     * The repository is public, so a stranger can open a pull request
+     * and run a workflow against it. What keeps that workflow away from
+     * the deploy role is this one condition, matched exactly: a
+     * StringLike with a wildcard would let any branch, and any fork,
+     * present a token that fits.
+     */
+    @Test
+    void onlyMainOnThisRepositoryCanAssumeTheRole() {
+        Map<?, ?> condition = trustCondition();
+
+        assertThat(condition.get("StringEquals"))
+                .as("both the audience and the subject are pinned")
+                .isEqualTo(Map.of(
+                        "token.actions.githubusercontent.com:aud", "sts.amazonaws.com",
+                        "token.actions.githubusercontent.com:sub",
+                        "repo:brandon-sanchez/Otto:ref:refs/heads/main"));
+        assertThat(String.valueOf(condition))
+                .as("no loose matcher alongside the exact one")
+                .doesNotContain("StringLike");
+    }
+
+    @Test
+    void theTrustIsAWebIdentityHandshakeAndNotALongLivedKey() {
+        Map<?, ?> statement = trustStatement();
+
+        assertThat(statement.get("Action")).isEqualTo("sts:AssumeRoleWithWebIdentity");
+        assertThat(String.valueOf(statement.get("Principal")))
+                .as("the federated principal is the GitHub provider this stack creates")
+                .contains("GithubOidc");
+        template.resourceCountIs("AWS::IAM::User", 0);
+        template.resourceCountIs("AWS::IAM::AccessKey", 0);
+    }
+
+    /**
+     * The role is a doorway to the bootstrap roles and nothing else. A
+     * deploy that needs a permission it does not have should fail
+     * loudly rather than find one waiting here.
+     */
+    @Test
+    void theRoleMayAssumeTheThreeBootstrapRolesAndNothingElse() {
+        List<?> statements = inlineStatements();
+
+        assertThat(statements).hasSize(1);
+        Map<?, ?> statement = (Map<?, ?>) statements.getFirst();
+        assertThat(statement.get("Action")).isEqualTo("sts:AssumeRole");
+
+        List<String> arns = ((List<?>) statement.get("Resource")).stream()
+                .map(String::valueOf)
+                .toList();
+        assertThat(arns).as("three roles, and no fourth").hasSize(3);
+        assertThat(arns)
+                .as("the partition is read off the stack rather than assumed to be \"aws\"")
+                .allSatisfy(arn -> assertThat(arn).contains("Ref=AWS::Partition"));
+        assertThat(String.valueOf(arns))
+                .contains("cdk-hnb659fds-lookup-role-%s-us-east-1".formatted(ACCOUNT))
+                .contains("cdk-hnb659fds-file-publishing-role-%s-us-east-1".formatted(ACCOUNT))
+                .contains("cdk-hnb659fds-deploy-role-%s-us-east-1".formatted(ACCOUNT));
+    }
+
+    /**
+     * cfn-exec is the role CloudFormation itself assumes, and it
+     * carries the permissions to create anything in the account.
+     * Granting it to the pipeline would hand a workflow the account.
+     */
+    @Test
+    void theExecutionRoleIsNotSomethingThePipelineCanAssume() {
+        assertThat(String.valueOf(inlineStatements())).doesNotContain("cfn-exec");
+    }
+
+    @Test
+    void noPolicyReachesEveryResourceOrEveryAction() {
+        String policies = String.valueOf(template.findResources("AWS::IAM::Policy"));
+
+        assertThat(policies).doesNotContain("\"*\"");
+        assertThat(template.findResources("AWS::IAM::Role").values())
+                .as("nothing managed and account-wide, such as AdministratorAccess")
+                .allSatisfy(role -> assertThat(String.valueOf(role))
+                        .doesNotContain("ManagedPolicyArns"));
+    }
+
+    /**
+     * The workflow holds this ARN as a repository secret. A generated
+     * name would change on a redeploy and break the pipeline in a way
+     * that looks like an AWS outage.
+     */
+    @Test
+    void theRoleNameIsFixedSoTheWorkflowsArnKeepsWorking() {
+        template.hasResourceProperties("AWS::IAM::Role",
+                Match.objectLike(Map.of("RoleName", "otto-github-deploy")));
+        assertThat(template.findOutputs("DeployRoleArn")).isNotEmpty();
+    }
+
+    private Map<?, ?> trustStatement() {
+        Map<String, Map<String, Object>> roles = template.findResources("AWS::IAM::Role");
+        assertThat(roles).hasSize(1);
+        Map<?, ?> properties = (Map<?, ?>) roles.values().iterator().next().get("Properties");
+        Map<?, ?> document = (Map<?, ?>) properties.get("AssumeRolePolicyDocument");
+        List<?> statements = (List<?>) document.get("Statement");
+        assertThat(statements).as("one way in, not several").hasSize(1);
+        return (Map<?, ?>) statements.getFirst();
+    }
+
+    private Map<?, ?> trustCondition() {
+        return (Map<?, ?>) trustStatement().get("Condition");
+    }
+
+    private List<?> inlineStatements() {
+        Map<String, Map<String, Object>> policies = template.findResources("AWS::IAM::Policy");
+        assertThat(policies).hasSize(1);
+        Map<?, ?> properties = (Map<?, ?>) policies.values().iterator().next().get("Properties");
+        Map<?, ?> document = (Map<?, ?>) properties.get("PolicyDocument");
+        return (List<?>) document.get("Statement");
+    }
+}


### PR DESCRIPTION
Closes #49.

## Why

On 2026-08-20 production was found running the build from 2026-08-13. Two fixes had been merged in between and neither was deployed - `2d1da07` (the commissioner transaction type) and `1f9d269` (the NFL season type). The second is the preseason fix, so for a week the deployed assistant read the wrong season's nflverse file while `main` held the code that read the right one.

Nothing errored. The heartbeat was healthy and no alarm fired, because a merged fix that is not deployed looks exactly like a fix that does not work. That is what this closes: not slow deploys, but silent ones.

## What changed

A single workflow. A pull request builds the Lambda zip, runs the app's tests and the infra template assertions, and deploys nothing. A push to `main` does the same and then deploys `OttoStack`.

The deploy installs the artifact the build produced rather than building its own, because the point of testing an artifact is to ship that artifact. Deploys are serialized, so two merges landing close together cannot race to publish versions and move the `live` alias.

## Authentication

The workflow holds no AWS key. The repository is public, and a stored access key would be one `pull_request_target` mistake away from being handed out.

GitHub mints a short-lived OIDC token, AWS trades it for session credentials, and the trust policy names exactly one repository and one branch with `StringEquals`. A wildcard there - `repo:owner/Otto:*` - would also match a pull request branch pushed by a stranger.

The role carries no permissions of its own. It may assume the `lookup`, `file-publishing` and `deploy` bootstrap roles and nothing else. `cfn-exec` is deliberately excluded: CloudFormation assumes it, the CLI does not, and it is the one that can create anything in the account.

## The role is in a stack the pipeline cannot deploy

`DeployRoleStack` is separate from `OttoStack`, and the workflow deploys `OttoStack` by name rather than `--all`. The pipeline therefore never holds the template defining its own permissions, so widening the deploy role takes a human at a terminal.

The cost is that a bare `cdk deploy` now refuses and asks which stack. `docs/deploy.md` is updated for that, and for the one-time role setup.

## Testing

- 207 app tests and 26 infra tests pass locally.
- `cdk synth OttoDeployRoleStack` produces the intended trust policy and grants.
- `DeployRoleStackTest` asserts the trust condition, the three assumable roles, the absence of a wildcard or a `*` resource, and that `cfn-exec` is not reachable.
- The build job on this pull request is itself the first real exercise of the workflow.

## Before merging

`OttoDeployRoleStack` must be deployed and the `AWS_DEPLOY_ROLE_ARN` and `ALERT_EMAIL` secrets set, or the first deploy on `main` will fail. Step 3 of `docs/deploy.md`.