### PR TITLE
fix: accept the subject GitHub actually sends, so the deploy can assume the role

### DIFF
--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -69,9 +69,19 @@ gh secret set AWS_DEPLOY_ROLE_ARN --body "$DEPLOY_ROLE_ARN"
 gh secret set ALERT_EMAIL --body 'you@example.com'
 ```
 
-The role trusts one repository and one branch. Renaming either, or
-moving the repo, means editing `SUBJECT` in `DeployRoleStack` and
-deploying it again by hand.
+The role trusts one repository and one branch, spelled two ways.
+GitHub sends a subject carrying the numeric ids of the owner and the
+repository, so a rename does not break the trust; the readable
+spelling is listed beside it in case GitHub goes back to sending that
+one. Moving the repo to another account means new ids, and so means
+editing `SUBJECTS` in `DeployRoleStack` and deploying it again by
+hand.
+
+The ids come from GitHub, not from guesswork:
+
+```sh
+gh api repos/OWNER/REPO/actions/oidc/customization/sub
+```
 
 ## 4. Point Telegram at the webhook
 

--- a/infra/src/main/java/otto/infra/DeployRoleStack.java
+++ b/infra/src/main/java/otto/infra/DeployRoleStack.java
@@ -48,8 +48,25 @@ public class DeployRoleStack extends Stack {
      * wildcard here is the standard way this goes wrong: {@code
      * repo:owner/Otto:*} would also match every pull request branch,
      * including one opened from a fork by a stranger.
+     *
+     * <p>Two spellings of the same subject, because GitHub has two.
+     * The readable one names the owner and repository; the other
+     * carries their numeric ids, which is what GitHub actually sent on
+     * the first real deploy - the run failed with {@code Not
+     * authorized to perform sts:AssumeRoleWithWebIdentity} and
+     * CloudTrail showed a subject this policy did not list. The ids
+     * are the point of that format: they survive a rename, where the
+     * readable form does not.
+     *
+     * <p>StringEquals against a list matches if any one value matches,
+     * so both are exact and neither widens what may assume the role.
+     * Both are listed rather than only the current one, because which
+     * format GitHub sends is GitHub's to change, and a deploy that
+     * stops working on their schedule is worth one extra line here.
      */
-    private static final String SUBJECT = "repo:brandon-sanchez/Otto:ref:refs/heads/main";
+    private static final List<String> SUBJECTS = List.of(
+            "repo:brandon-sanchez/Otto:ref:refs/heads/main",
+            "repo:brandon-sanchez@83891046/Otto@1325745376:ref:refs/heads/main");
 
     /**
      * The qualifier CDK bootstrapped this account with - the {@code
@@ -96,7 +113,7 @@ public class DeployRoleStack extends Stack {
                         github.getAttrArn(),
                         Map.of("StringEquals", Map.of(
                                 "token.actions.githubusercontent.com:aud", AUDIENCE,
-                                "token.actions.githubusercontent.com:sub", SUBJECT)),
+                                "token.actions.githubusercontent.com:sub", SUBJECTS)),
                         "sts:AssumeRoleWithWebIdentity"))
                 .build();
 

--- a/infra/src/test/java/otto/infra/DeployRoleStackTest.java
+++ b/infra/src/test/java/otto/infra/DeployRoleStackTest.java
@@ -49,20 +49,44 @@ class DeployRoleStackTest {
      * the deploy role is this one condition, matched exactly: a
      * StringLike with a wildcard would let any branch, and any fork,
      * present a token that fits.
+     *
+     * <p>Both spellings of the subject are accepted, and both are
+     * exact. GitHub sends the one carrying numeric ids; the readable
+     * one is kept in case that changes back.
      */
     @Test
     void onlyMainOnThisRepositoryCanAssumeTheRole() {
         Map<?, ?> condition = trustCondition();
+        Map<?, ?> equals = (Map<?, ?>) condition.get("StringEquals");
 
-        assertThat(condition.get("StringEquals"))
-                .as("both the audience and the subject are pinned")
-                .isEqualTo(Map.of(
-                        "token.actions.githubusercontent.com:aud", "sts.amazonaws.com",
-                        "token.actions.githubusercontent.com:sub",
-                        "repo:brandon-sanchez/Otto:ref:refs/heads/main"));
+        assertThat(equals.get("token.actions.githubusercontent.com:aud"))
+                .isEqualTo("sts.amazonaws.com");
+        assertThat((List<?>) equals.get("token.actions.githubusercontent.com:sub"))
+                .extracting(String::valueOf)
+                .containsExactlyInAnyOrder(
+                        "repo:brandon-sanchez/Otto:ref:refs/heads/main",
+                        "repo:brandon-sanchez@83891046/Otto@1325745376:ref:refs/heads/main");
         assertThat(String.valueOf(condition))
-                .as("no loose matcher alongside the exact one")
+                .as("no loose matcher alongside the exact ones")
                 .doesNotContain("StringLike");
+    }
+
+    /**
+     * The first live deploy failed because the policy listed only the
+     * readable subject and GitHub sent the one with ids. Every accepted
+     * subject must still name this repository and this branch, so a
+     * later edit cannot quietly widen the door.
+     */
+    @Test
+    void everyAcceptedSubjectNamesThisRepositoryAndOnlyMain() {
+        Map<?, ?> equals = (Map<?, ?>) trustCondition().get("StringEquals");
+
+        assertThat((List<?>) equals.get("token.actions.githubusercontent.com:sub"))
+                .allSatisfy(subject -> assertThat(String.valueOf(subject))
+                        .startsWith("repo:brandon-sanchez")
+                        .contains("/Otto")
+                        .endsWith(":ref:refs/heads/main")
+                        .doesNotContain("*"));
     }
 
     @Test


### PR DESCRIPTION
Follow-up to #50. The first deploy on `main` failed; this is the fix, and it is already deployed.

## What happened

Run [32461414337](https://github.com/brandon-sanchez/Otto/actions/runs/32461414337) built and tested cleanly, then failed at `configure-aws-credentials`. Twelve attempts, all refused:

```
Could not assume role with OIDC: Not authorized to perform sts:AssumeRoleWithWebIdentity
```

## Why

`DeployRoleStack` pinned the subject claim in its readable form:

```
repo:brandon-sanchez/Otto:ref:refs/heads/main
```

CloudTrail recorded what GitHub actually presented:

```
repo:brandon-sanchez@83891046/Otto@1325745376:ref:refs/heads/main
```

GitHub now carries the numeric ids of the owner and the repository in the subject claim. `gh api repos/OWNER/REPO/actions/oidc/customization/sub` reports the prefix it uses. A `StringEquals` against one literal cannot match that, so the policy denied a token that was correct in every other way.

This was the one part of #50 that could not be verified before merging, because only a real push to `main` mints a real token. It failed exactly there.

## The fix

Both spellings are listed. `StringEquals` against a list matches if any one value matches, so each stays exact and neither widens what may assume the role: both still name this repository and this branch, and neither contains a wildcard.

The id form is kept because it survives a rename, which the readable form does not. The readable form is kept because which format GitHub sends is GitHub's to change, and a deploy that stops working on their schedule is worth one extra line.

## Testing

- 27 infra tests pass, up from 26. The existing subject test now checks both values.
- A new test asserts that every accepted subject starts with `repo:brandon-sanchez`, contains `/Otto`, ends with `:ref:refs/heads/main`, and contains no `*`. A later edit cannot widen the door while still looking exact.
- `cdk diff` showed one changed property, the subject condition, and nothing else.

## Verified live

`OttoDeployRoleStack` is deployed and the failed job was re-run:

- `configure-aws-credentials` succeeded.
- `Deploy OttoStack` succeeded. `OttoStack` reached `UPDATE_COMPLETE` at 08:21:57 UTC.
- Both aliases moved to version 6.
- The Check loop logged `heartbeat check-completed` on the new code.
- Zero `ERROR` lines across all three log groups since the deploy.

The pipeline from #50 now works end to end.